### PR TITLE
Simple utilities for reading/writing to a zStandard compressed file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 
 script:
 # To start, run all the non-integration tests.
-- MODULES="inetdiag"
+- MODULES="inetdiag zstd"
 - for module in $MODULES; do
     COVER_PKGS=${COVER_PKGS}./$module/..., ;
   done

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,9 @@ install:
 - GO_IMPORTS=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v etl-gardener)
 - go get -u -v -d $GO_IMPORTS
 
+# Install zstd tool.
+- bash <(curl -fsSL https://raw.githubusercontent.com/horta/zstd.install/master/install)
+
 script:
 # To start, run all the non-integration tests.
 - MODULES="inetdiag zstd"

--- a/zstd/.gitignore
+++ b/zstd/.gitignore
@@ -1,0 +1,2 @@
+test.zst
+

--- a/zstd/.gitignore
+++ b/zstd/.gitignore
@@ -1,2 +1,0 @@
-test.zst
-

--- a/zstd/zstd.go
+++ b/zstd/zstd.go
@@ -1,0 +1,60 @@
+// Package zstd provides utilities for connecting to external zStandard compression tasks.
+package zstd
+
+import (
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"sync"
+)
+
+// NewReader creates a reader piped to external zstd process reading from file.
+// Read from returned pipe
+// Close pipe when done
+func NewReader(filename string) io.ReadCloser {
+	pipeR, pipeW, _ := os.Pipe()
+	cmd := exec.Command("zstd", "-d", "-c", filename)
+	cmd.Stdout = pipeW
+
+	f, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	f.Close()
+
+	go func() {
+		err := cmd.Run()
+		if err != nil {
+			log.Println("ZSTD error", filename, err)
+		}
+		pipeW.Close()
+	}()
+
+	return pipeR
+}
+
+// NewWriter creates a writer piped to an external zstd process writing to filename
+// Write to io.Writer
+// close io.Writer when done
+// wait on waitgroup to finish
+func NewWriter(filename string) (io.WriteCloser, *sync.WaitGroup) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	pipeR, pipeW, _ := os.Pipe()
+	f, _ := os.Create(filename)
+	cmd := exec.Command("zstd")
+	cmd.Stdin = pipeR
+	cmd.Stdout = f
+
+	go func() {
+		err := cmd.Run()
+		if err != nil {
+			log.Println("ZSTD error", filename, err)
+		}
+		pipeR.Close()
+		wg.Done()
+	}()
+
+	return pipeW, &wg
+}

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/m-lab/tcp-info/zstd"
 )
 
-func TestReader(t *testing.T) {
+func TestWriterReader(t *testing.T) {
 	tmpdir, err := ioutil.TempDir(".", "tmp")
 	if err != nil {
 		t.Fatal(err)

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -1,0 +1,40 @@
+package zstd_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/m-lab/tcp-info/zstd"
+)
+
+func TestReader(t *testing.T) {
+	data := make([]byte, 10000)
+	for i := range data {
+		data[i] = byte((i * 37) % 256)
+	}
+
+	w, wg := zstd.NewWriter("./test.zst")
+	n, err := w.Write(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	wg.Wait()
+
+	read := make([]byte, 20000)
+	r := zstd.NewReader("./test.zst")
+	// Interesting...  Sometimes this requires multiple calls to read.
+	n, err = io.ReadAtLeast(r, read, 10000)
+	if err != nil {
+		t.Error(err)
+	}
+	if n != 10000 {
+		t.Error("Wrong number of bytes", n)
+	}
+
+	for i := range data {
+		if data[i] != read[i] {
+			t.Fatal("Data mismatch at", i)
+		}
+	}
+}

--- a/zstd/zstd_test.go
+++ b/zstd/zstd_test.go
@@ -2,18 +2,32 @@ package zstd_test
 
 import (
 	"io"
+	"io/ioutil"
+	"os/exec"
 	"testing"
 
 	"github.com/m-lab/tcp-info/zstd"
 )
 
 func TestReader(t *testing.T) {
+	tmpdir, err := ioutil.TempDir(".", "tmp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		cmd := exec.Command("rm", "-rf", tmpdir)
+		err = cmd.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
 	data := make([]byte, 10000)
 	for i := range data {
 		data[i] = byte((i * 37) % 256)
 	}
 
-	w, wg := zstd.NewWriter("./test.zst")
+	w, wg := zstd.NewWriter(tmpdir + "/test.zst")
 	n, err := w.Write(data)
 	if err != nil {
 		t.Fatal(err)
@@ -22,7 +36,7 @@ func TestReader(t *testing.T) {
 	wg.Wait()
 
 	read := make([]byte, 20000)
-	r := zstd.NewReader("./test.zst")
+	r := zstd.NewReader(tmpdir + "/test.zst")
 	// Interesting...  Sometimes this requires multiple calls to read.
 	n, err = io.ReadAtLeast(r, read, 10000)
 	if err != nil {


### PR DESCRIPTION
zstd is a compression utility well suited to tcpinfo proto or raw netlink message handling.
There is a golang wrapper, but it doesn't work properly for streaming data, and also involves cgo, which is nice to avoid.

Part of story #2 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/7)
<!-- Reviewable:end -->
