### PR TITLE
Add a Dockerfile to build a containerized tcp-info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 # This filters out all imports from the local project, and all "base" imports that don't contain slash.
 - GO_IMPORTS=$(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -e / | grep -v m-lab/tcp-info)
 - go get -u -v -d $GO_IMPORTS
-- go get github.com/golang/protobuf/protoc-gen-go/
+- go get github.com/golang/protobuf/protoc-gen-go/ github.com/golang/protobuf/proto
 
 # Install protobuf compiler
 - wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
@@ -91,6 +91,8 @@ script:
 - $HOME/gopath/bin/gocovmerge *.cov > merge.cov
 - $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
 
+# Docker build
+- docker build -t mlab/tcpinfo .
 
 #################################################################################
 # Deployment Section

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM alpine as zstd-builder
+
+RUN apk --no-cache add make gcc libc-dev git
+
+RUN git clone https://github.com/facebook/zstd src
+
+RUN mkdir /pkg && cd /src && make && make DESTDIR=/pkg install
+
+# Second minimal image to only keep the built binary
+FROM electrotumbao/golang-protoc as go-builder
+
+RUN apk update && apk add bash git unzip
+
+WORKDIR /go/src/github.com/m-lab
+RUN git clone --branch docker https://github.com/m-lab/tcp-info
+WORKDIR tcp-info
+RUN ls -l
+
+# List all of the go imports, excluding any in this repo, and run go get to import them.
+RUN go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v m-lab/tcp-info)
+#RUN go get github.com/golang/protobuf/protoc-gen-go/
+#RUN wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+#RUN unzip protoc-3.5.1-linux-x86_64.zip  # Should provide bin/protoc
+#RUN bin/protoc
+
+WORKDIR nl-proto
+RUN protoc --go_out=. *.proto
+WORKDIR ..
+
+# Install all go executables.  Should create tcp-info in go/bin directory.
+RUN go install -v ./...
+
+FROM alpine
+
+RUN apk --no-cache add bash
+
+# Copy the built files
+COPY --from=zstd-builder /pkg /
+
+# Copy the license as well
+RUN mkdir -p /usr/local/share/licenses/zstd
+COPY --from=zstd-builder /src/LICENSE /usr/local/share/licences/zstd/
+
+COPY --from=go-builder /go/bin /
+
+EXPOSE 9090 8080
+
+CMD tcp-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,7 @@ RUN ls -l
 
 # List all of the go imports, excluding any in this repo, and run go get to import them.
 RUN go get -u -v $(go list -f '{{join .Imports "\n"}}{{"\n"}}{{join .TestImports "\n"}}' ./... | sort | uniq | grep -v m-lab/tcp-info)
-#RUN go get github.com/golang/protobuf/protoc-gen-go/
-#RUN wget https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
-#RUN unzip protoc-3.5.1-linux-x86_64.zip  # Should provide bin/protoc
-#RUN bin/protoc
+RUN go get github.com/golang/protobuf/protoc-gen-go/ github.com/golang/protobuf/proto
 
 WORKDIR nl-proto
 RUN protoc --go_out=. *.proto


### PR DESCRIPTION
There isn't currently any executable, but this will do the right thing when there is one.

TODO: Figure out how to leverage docker build in gcr.io, instead of building it twice.