### PR TITLE
Fix Dockerfile branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ script:
 - $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
 
 # Docker build
-- docker build -t mlab/tcpinfo .
+- docker build --build-arg COMMIT=$TRAVIS_BRANCH -t mlab/tcpinfo .
 
 #################################################################################
 # Deployment Section

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,24 +27,24 @@ WORKDIR nl-proto
 RUN protoc --go_out=. *.proto
 WORKDIR ..
 
-# Install all go executables.  Should create tcp-info in go/bin directory.
+# Install all go executables.  Creates all build targets in /go/bin directory.
 RUN go install -v ./...
 
 FROM alpine
 
 RUN apk --no-cache add bash
 
-WORKDIR /home
 
-# Copy the built files
+# Copy the built files (from /pkg/usr/local/bin)
 COPY --from=zstd-builder /pkg /
 
 # Copy the license as well
 RUN mkdir -p /usr/local/share/licenses/zstd
 COPY --from=zstd-builder /src/LICENSE /usr/local/share/licences/zstd/
 
-COPY --from=go-builder /go/bin .
+COPY --from=go-builder /go/bin /usr/local/bin
 
 EXPOSE 9090 8080
 
-CMD ./tcp-info
+WORKDIR /home
+CMD tcp-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM electrotumbao/golang-protoc as go-builder
 RUN apk update && apk add bash git unzip
 
 WORKDIR /go/src/github.com/m-lab
-RUN git clone --branch docker https://github.com/m-lab/tcp-info
+RUN git clone --branch master https://github.com/m-lab/tcp-info
 WORKDIR tcp-info
 RUN ls -l
 


### PR DESCRIPTION
Dockerfile explicitly used docker branch, instead of using the branch associated with the PR.

This PR adds docker and travis tweaks so that docker builds the appropriate branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/14)
<!-- Reviewable:end -->
