### PR TITLE
Can now find all network namespaces in /proc

### DIFF
--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -10,8 +10,15 @@ import (
 	"time"
 )
 
+// ErrCantReadProc is the error returned when the /proc filesystem is, for
+// whatever reason, currently unreadable.
 var ErrCantReadProc = errors.New("Can't read /proc")
 
+// WatchForNetworkNamespaces repeatedly polls the /proc filesystem to discover
+// all known network namespaces. We would prefer that this polling loop actually
+// be a thing with a notifier, but it appears that polling truly is the state of
+// the art here. Any system which uses this will need to filter the incoming
+// firehose, as many namespaces will be reported multiple times.
 func WatchForNetworkNamespaces(ctx context.Context, procfs string, nsChan chan<- string) error {
 	keepGoing := true
 	go func() {
@@ -25,6 +32,7 @@ func WatchForNetworkNamespaces(ctx context.Context, procfs string, nsChan chan<-
 		if err != nil {
 			return err
 		}
+		// Listen for new network namespaces 100 times per second.
 		time.Sleep(10 * time.Millisecond)
 	}
 	return nil

--- a/namespaces/namespaces.go
+++ b/namespaces/namespaces.go
@@ -1,0 +1,76 @@
+package namespaces
+
+import (
+	"context"
+	"errors"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var ErrCantReadProc = errors.New("Can't read /proc")
+
+func WatchForNetworkNamespaces(ctx context.Context, procfs string, nsChan chan<- string) error {
+	keepGoing := true
+	go func() {
+		<-ctx.Done()
+		keepGoing = false
+	}()
+	defer close(nsChan)
+
+	for keepGoing {
+		err := listNetworkNamespaces(procfs, nsChan)
+		if err != nil {
+			return err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return nil
+}
+
+func listNetworkNamespaces(procfs string, nsChan chan<- string) error {
+	d, err := os.Open(procfs)
+	if err != nil {
+		return ErrCantReadProc
+	}
+
+	subdirs, err := d.Readdirnames(0)
+	if err != nil {
+		return ErrCantReadProc
+	}
+
+	for _, subdir := range subdirs {
+		_, err := strconv.Atoi(subdir)
+		if err != nil {
+			continue
+		}
+		// Now we know that the subdir of /proc is an int, which means it is a PID.
+		// Let us look to see if it contains ns/net
+		nsFile, err := os.Readlink(procfs + "/" + subdir + "/ns/net")
+		if err != nil {
+			// No net namespace for PID.
+			continue
+		}
+		chunks := strings.Split(nsFile, ":")
+		if len(chunks) < 2 {
+			log.Println("Ill-formatted net namespace:", nsFile)
+			continue
+		}
+		pid := chunks[len(chunks)-1]
+		if len(pid) <= 2 {
+			log.Println("Namespace has no colon:", nsFile)
+			continue
+		}
+		pid = pid[1 : len(pid)-1]
+		_, err = strconv.ParseUint(pid, 10, 64)
+		if err != nil {
+			log.Println("Namespace is not an integer:", nsFile)
+			continue
+		}
+		nsChan <- pid
+	}
+
+	return nil
+}

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -39,7 +39,7 @@ func makeFakeProc(prefix string) string {
 func TestListForeverCancelWorks(t *testing.T) {
 	fakeProc := makeFakeProc("TestListForeverCancelWorks")
 	log.Println(fakeProc)
-	//defer os.RemoveAll(fakeProc)
+	defer os.RemoveAll(fakeProc)
 
 	nsChan := make(chan string)
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/namespaces/namespaces_test.go
+++ b/namespaces/namespaces_test.go
@@ -1,0 +1,81 @@
+package namespaces_test
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/tcp-info/namespaces"
+)
+
+func makeFakeProc(prefix string) string {
+	d, err := ioutil.TempDir("", prefix)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Two PIDs with namespaces.
+	rtx.Must(os.MkdirAll(d+"/proc/123/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/123/ns/net:[4026532008]", d+"/proc/123/ns/net"), "Could not create symlink")
+	rtx.Must(os.MkdirAll(d+"/proc/456/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/456/ns/net:[4026532010]", d+"/proc/456/ns/net"), "Could not create symlink")
+	// One PID with no namespace
+	rtx.Must(os.MkdirAll(d+"/proc/789/", 0777), "Could not created fake proc")
+	// A bunch of stuff that should never appear in practice.
+	rtx.Must(os.MkdirAll(d+"/proc/457/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/457/ns/net:[]", d+"/proc/457/ns/net"), "Could not create symlink")
+	rtx.Must(os.MkdirAll(d+"/proc/458/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/458/ns/net[]", d+"/proc/458/ns/net"), "Could not create symlink")
+	rtx.Must(os.MkdirAll(d+"/proc/apple/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/apple/ns/net:[4026532010]", d+"/proc/apple/ns/net"), "Could not create symlink")
+	rtx.Must(os.MkdirAll(d+"/proc/459/ns/", 0777), "Could not created fake proc")
+	rtx.Must(os.Symlink(d+"/proc/459/ns/net:[orange]", d+"/proc/459/ns/net"), "Could not create symlink")
+	return d
+}
+
+func TestListForeverCancelWorks(t *testing.T) {
+	fakeProc := makeFakeProc("TestListForeverCancelWorks")
+	log.Println(fakeProc)
+	//defer os.RemoveAll(fakeProc)
+
+	nsChan := make(chan string)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	go namespaces.WatchForNetworkNamespaces(ctx, fakeProc+"/proc", nsChan)
+
+	ns := make(map[string]struct{})
+	for n := range nsChan {
+		ns[n] = struct{}{}
+	}
+	if len(ns) != 2 {
+		t.Errorf("Wrong number of namespaces")
+	}
+}
+
+func TestBadProcFails(t *testing.T) {
+	nsChan := make(chan string)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err := namespaces.WatchForNetworkNamespaces(ctx, "/ThisFileShouldNotExist", nsChan)
+	if err != namespaces.ErrCantReadProc {
+		t.Error("Should have failed with ErrCantReadProc")
+	}
+}
+
+func TestProcAsFileFails(t *testing.T) {
+	f, err := ioutil.TempFile("", "TestProcAsFileFails")
+	if err != nil {
+		t.Errorf("Could not make TempFile(%v)", err)
+	}
+	nsChan := make(chan string)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	err = namespaces.WatchForNetworkNamespaces(ctx, f.Name(), nsChan)
+	if err != namespaces.ErrCantReadProc {
+		t.Error("Should have failed with ErrCantReadProc")
+	}
+}


### PR DESCRIPTION
It looks like this really is the recommended way of doing this. Any
system which uses this will need to filter the incoming firehose, as
many namespaces will be reported multiple times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/29)
<!-- Reviewable:end -->
