### PR TITLE
Rate limit and metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ script:
 - cd $TRAVIS_BUILD_DIR
 
 # To start, run all the non-integration tests.
+- go vet ./...
+- go build ./...
 - MODULES="inetdiag zstd nl-proto/pbtools cache saver"
 - for module in $MODULES; do
     COVER_PKGS=${COVER_PKGS}./$module/..., ;

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -46,11 +46,11 @@ func (c *Cache) Update(msg *inetdiag.ParsedMessage) *inetdiag.ParsedMessage {
 // It returns all messages that did not have corresponding inodes in the most recent
 // batch of messages.
 func (c *Cache) EndCycle() map[uint64]*inetdiag.ParsedMessage {
-	metrics.CacheSizeSummary.Observe(float64(len(c.current)))
+	metrics.CacheSizeHistogram.Observe(float64(len(c.current)))
 	tmp := c.previous
 	c.previous = c.current
 	// Allocate a bit more than previous size, to accommodate new connections.
-	// This this will grow and shrink with the number of active connections, but
+	// This will grow and shrink with the number of active connections, but
 	// minimize reallocation.
 	c.current = make(map[uint64]*inetdiag.ParsedMessage, len(c.previous)+len(c.previous)/10+10)
 	c.cycles++
@@ -59,6 +59,6 @@ func (c *Cache) EndCycle() map[uint64]*inetdiag.ParsedMessage {
 
 // CycleCount returns the number of times EndCycle() has been called.
 func (c *Cache) CycleCount() int64 {
-	// TODO also add a prometheus counter for this.
+	// Don't need a prometheus counter, because we already have the count of CacheSizeHistogram observations.
 	return c.cycles
 }

--- a/inetdiag/socket-monitor.go
+++ b/inetdiag/socket-monitor.go
@@ -56,12 +56,12 @@ func makeReq(inetType uint8) *nl.NetlinkRequest {
 func processSingleMessage(m *syscall.NetlinkMessage, seq uint32, pid uint32) (*syscall.NetlinkMessage, bool, error) {
 	if m.Header.Seq != seq {
 		log.Printf("Wrong Seq nr %d, expected %d", m.Header.Seq, seq)
-		metrics.ErrorCount.With(prometheus.Labels{"source": "wrong seq num"}).Inc()
+		metrics.ErrorCount.With(prometheus.Labels{"type": "wrong seq num"}).Inc()
 		return nil, false, ErrBadSequence
 	}
 	if m.Header.Pid != pid {
 		log.Printf("Wrong pid %d, expected %d", m.Header.Pid, pid)
-		metrics.ErrorCount.With(prometheus.Labels{"source": "wrong pid"}).Inc()
+		metrics.ErrorCount.With(prometheus.Labels{"type": "wrong pid"}).Inc()
 		return nil, false, ErrBadPid
 	}
 	if m.Header.Type == unix.NLMSG_DONE {
@@ -74,7 +74,7 @@ func processSingleMessage(m *syscall.NetlinkMessage, seq uint32, pid uint32) (*s
 			return nil, false, nil
 		}
 		log.Println(syscall.Errno(-error))
-		metrics.ErrorCount.With(prometheus.Labels{"source": "NLMSG_ERROR"}).Inc()
+		metrics.ErrorCount.With(prometheus.Labels{"type": "NLMSG_ERROR"}).Inc()
 	}
 	if m.Header.Flags&unix.NLM_F_MULTI == 0 {
 		return m, false, nil

--- a/inetdiag/socket-monitor.go
+++ b/inetdiag/socket-monitor.go
@@ -96,7 +96,7 @@ func OneType(inetType uint8) ([]*syscall.NetlinkMessage, error) {
 		case syscall.AF_INET6:
 			af = "ipv6"
 		}
-		metrics.SyscallTimeMsec.With(prometheus.Labels{"af": af}).Observe(1000 * time.Since(start).Seconds())
+		metrics.SyscallTimeHistogram.With(prometheus.Labels{"af": af}).Observe(time.Since(start).Seconds())
 		metrics.ConnectionCountHistogram.With(prometheus.Labels{"af": af}).Observe(float64(len(res)))
 	}()
 

--- a/inetdiag/socket-monitor.go
+++ b/inetdiag/socket-monitor.go
@@ -96,8 +96,8 @@ func OneType(inetType uint8) ([]*syscall.NetlinkMessage, error) {
 		case syscall.AF_INET6:
 			af = "ipv6"
 		}
-		metrics.FetchTimeMsecSummary.With(prometheus.Labels{"af": af}).Observe(1000 * time.Since(start).Seconds())
-		metrics.ConnectionCountSummary.With(prometheus.Labels{"af": af}).Observe(float64(len(res)))
+		metrics.SyscallTimeMsec.With(prometheus.Labels{"af": af}).Observe(1000 * time.Since(start).Seconds())
+		metrics.ConnectionCountHistogram.With(prometheus.Labels{"af": af}).Observe(float64(len(res)))
 	}()
 
 	req := makeReq(inetType)

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 	svrChan := make(chan []*inetdiag.ParsedMessage, 2)
 	go svr.MessageSaverLoop(svrChan)
 
-	nextTime := time.Now()
+	ticker := time.NewTicker(10 * time.Millisecond)
 
 	for loops = 0; *reps == 0 || loops < *reps; loops++ {
 		total, remote := CollectDefaultNamespace(svrChan)
@@ -175,17 +175,10 @@ func main() {
 			Stats(svr)
 		}
 
-		// For now, cap rate at 100 Hz.
-		nextTime = nextTime.Add(10 * time.Millisecond)
-		// If we get more than 5 msec behind, clamp there, to avoid bursts.
-		if nextTime.Before(time.Now().Add(5 * time.Millisecond)) {
-			nextTime = time.Now().Add(5 * time.Millisecond)
-		}
-		delay := nextTime.Sub(time.Now())
-		if delay > 0 {
-			time.Sleep(delay)
-		}
+		// Wait for next tick.
+		<-ticker
 	}
+	ticker.Stop()
 
 	close(svrChan)
 	svr.Done.Wait()

--- a/main.go
+++ b/main.go
@@ -176,7 +176,7 @@ func main() {
 		}
 
 		// Wait for next tick.
-		<-ticker
+		<-ticker.C
 	}
 	ticker.Stop()
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,6 +19,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+// SetupPrometheus configures prometheus metrics on the specified port.
+// If promPort is zero, it will ask the system to choose a port (e.g. for testing).
+// Also registers pprof handlers on the same port.
 func SetupPrometheus(promPort int) *http.Server {
 	if promPort < 0 {
 		log.Println("Not exporting prometheus metrics")

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -10,7 +10,6 @@ package metrics
 import (
 	"fmt"
 	"log"
-	"math"
 	"net/http"
 	"net/http/pprof"
 
@@ -43,14 +42,8 @@ func SetupPrometheus(promPort int) {
 	prometheus.MustRegister(ConnectionCountHistogram)
 	prometheus.MustRegister(CacheSizeHistogram)
 
-	prometheus.MustRegister(EntryFieldCountHistogram)
-	prometheus.MustRegister(FileSizeHistogram)
-	prometheus.MustRegister(RowSizeHistogram)
-
-	// Common metrics
-	prometheus.MustRegister(FileCount)
+	prometheus.MustRegister(NewFileCount)
 	prometheus.MustRegister(ErrorCount)
-	prometheus.MustRegister(WarningCount)
 
 	port := fmt.Sprintf(":%d", promPort)
 	log.Println("Exporting prometheus metrics on", port)
@@ -105,126 +98,27 @@ var (
 			},
 		})
 
-	// ErrorCount measures the number of annotation errors
+	// ErrorCount measures the number of errors
 	// Provides metrics:
 	//    tcpinfo_Error_Count
 	// Example usage:
-	//    metrics.ErrorCount.With(prometheus.Labels{"source", "foobar"}).Inc()
+	//    metrics.ErrorCount.With(prometheus.Labels{"type", "foobar"}).Inc()
 	ErrorCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "tcpinfo_Error_Count",
+			Name: "tcpinfo_error_count",
 			Help: "The total number of errors encountered.",
-		}, []string{"source"})
+		}, []string{"type"})
 
-	// WarningCount measures the number of annotation warnings
-	// Provides metrics:
-	//    tcpinfo_Warning_Count
-	// Example usage:
-	//    metrics.WarningCount.With(prometheus.Labels{"source", "foobar"}).Inc()
-	WarningCount = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "tcpinfo_Warning_Count",
-			Help: "The total number of Warnings encountered.",
-		}, []string{"source"})
-
-	// FileCount counts the number of files written.
+	// NewFileCount counts the number of connection files written.
 	//
 	// Provides metrics:
-	//   tcpinfo_New_File_Count
+	//   tcpinfo_new_file_count
 	// Example usage:
 	//   metrics.FileCount.Inc()
-	FileCount = prometheus.NewCounter(
+	NewFileCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "tcpinfo_New_File_Count",
+			Name: "tcpinfo_new_file_count",
 			Help: "Number of files created.",
 		},
-	)
-
-	// TODO(dev): bytes/row - generalize this metric for any file type.
-	//
-	// RowSizeHistogram provides a histogram of bq row json sizes.  It is intended primarily for
-	// NDT, so the bins are fairly large.  NDT average json is around 200K
-	//
-	// Provides metrics:
-	//   etl_row_json_size_bucket{table="...", le="..."}
-	//   ...
-	//   etl_row_json_size_sum{table="...", le="..."}
-	//   etl_row_json_size_count{table="...", le="..."}
-	// Usage example:
-	//   metrics.RowSizeHistogram.WithLabelValues(
-	//           "ndt").Observe(len(json))
-	RowSizeHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "etl_row_json_size",
-			Help: "Row json size distributions.",
-			Buckets: []float64{
-				0,
-				100, 130, 180, 240, 320, 420, 560, 750,
-				1000, 1300, 1800, 2400, 3200, 4200, 5600, 7500,
-				10000, 13000, 18000, 24000, 32000, 42000, 56000, 75000,
-				100000, 130000, 180000, 240000, 320000, 420000, 560000, 750000,
-				1000000, 1300000, 1800000, 2400000, 3200000, 4200000, 5600000, 7500000,
-				10000000, // 10MiB
-				math.Inf(+1),
-			},
-		},
-		[]string{"table"},
-	)
-
-	// TODO(dev): rows/test - generalize this metric for any file type.
-	//
-	// EntryFieldCountHistogram provides a histogram of (approximate) row field counts.  It is intended primarily for
-	// NDT, so the bins are fairly large.  NDT snapshots typically total about 10k
-	// fields, 99th percentile around 35k fields, and occasionally as many as 50k.
-	// Smaller field count bins included so that it is possibly useful for other
-	// parsers.
-	//
-	// Provides metrics:
-	//   etl_entry_field_count_bucket{table="...", le="..."}
-	//   ...
-	//   etl_entry_field_count_sum{table="...", le="..."}
-	//   etl_entry_field_count_count{table="...", le="..."}
-	// Usage example:
-	//   metrics.EntryFieldCountHistogram.WithLabelValues(
-	//           "ndt").Observe(fieldCount)
-	EntryFieldCountHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "etl_entry_field_count",
-			Help: "total snapshot field count distributions.",
-			Buckets: []float64{
-				0,
-				10, 13, 18, 24, 32, 42, 56, 75,
-				100, 130, 180, 240, 320, 420, 560, 750,
-				1000, 1300, 1800, 2400, 3200, 4200, 5600, 7500,
-				10000, 13000, 18000, 24000, 32000, 42000, 56000, 75000,
-				100000, 130000, 180000, 240000, 320000, 420000, 560000, 750000,
-				1000000, // 1 MiB
-				math.Inf(+1),
-			},
-		},
-		[]string{"table"},
-	)
-
-	// FileSizeHistogram provides a histogram of source file sizes. The bucket
-	// sizes should cover a wide range of input file sizes, but should not have too
-	// many buckets, because there are also three vector dimensions.
-	//
-	// Example usage:
-	//   metrics.FileSizeHistogram.WithLabelValues(
-	//       "ndt", "c2s_snaplog", "parsed").Observe(size)
-	FileSizeHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "etl_test_file_size_bytes",
-			Help: "Size of individual test files.",
-			Buckets: []float64{
-				0,
-				1000, 2500, 5000, 10000, 25000, 50000,
-				100000, 250000, 500000, 1000000, 2500000, 5000000,
-				10000000, 25000000, 50000000, 100000000, 250000000, 500000000,
-				1000000000, // 1 gb
-				math.Inf(+1),
-			},
-		},
-		[]string{"table", "kind", "group"},
 	)
 )

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,0 +1,35 @@
+package metrics_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/m-lab/tcp-info/metrics"
+	"github.com/prometheus/prometheus/util/promlint"
+)
+
+func TestPrometheusMetrics(t *testing.T) {
+	server := metrics.SetupPrometheus(0)
+	defer server.Shutdown(nil)
+	log.Println(server.Addr)
+
+	metricReader, err := http.Get("http://" + server.Addr + "/metrics")
+	if err != nil || metricReader == nil {
+		t.Fatalf("Could not GET metrics: %v", err)
+	}
+	metricBytes, err := ioutil.ReadAll(metricReader.Body)
+	if err != nil {
+		t.Fatalf("Could not read metrics: %v", err)
+	}
+	metricsLinter := promlint.New(bytes.NewBuffer(metricBytes))
+	problems, err := metricsLinter.Lint()
+	if err != nil {
+		t.Errorf("Could not lint metrics: %v", err)
+	}
+	for _, p := range problems {
+		t.Errorf("Bad metric %v: %v", p.Metric, p.Text)
+	}
+}

--- a/saver/saver.go
+++ b/saver/saver.go
@@ -127,7 +127,7 @@ func (conn *Connection) Rotate(Host string, Pod string, FileAgeLimit time.Durati
 	if err != nil {
 		return err
 	}
-	metrics.FileCount.Inc()
+	metrics.NewFileCount.Inc()
 	conn.Expiration = conn.Expiration.Add(10 * time.Minute)
 	conn.Sequence++
 	return nil


### PR DESCRIPTION
1.  Clean up metrics - use histogram instead of summary, unify naming.
2.  Add a fixed rate limit - 100 Hz.
3.  Add pprof sampling of mutex and blocking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/40)
<!-- Reviewable:end -->
