### PR TITLE
Fix csv marshaling for IDiagMsg

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -39,7 +39,7 @@ func fakeMsg(t *testing.T, cookie uint64, dport uint16) netlink.ArchivalRecord {
 	}
 	for i := 0; i < 2; i++ {
 		idm.ID.IDiagDPort[i] = byte(dport & 0x0FF)
-		cookie >>= 8
+		dport >>= 8
 	}
 	return *mp
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -39,7 +39,7 @@ func fakeMsg(t *testing.T, cookie uint64, dport uint16) netlink.ArchivalRecord {
 	}
 	for i := 0; i < 2; i++ {
 		idm.ID.IDiagDPort[i] = byte(dport & 0x0FF)
-		dport >>= 8
+		cookie >>= 8
 	}
 	return *mp
 }

--- a/cmd/csvtool/main_test.go
+++ b/cmd/csvtool/main_test.go
@@ -23,23 +23,26 @@ func TestFileToCSV(t *testing.T) {
 	}
 
 	header := strings.Split(lines[0], ",")
-	if header[7] != "IDiagFamily" {
-		t.Fatal("Incorrect header", header[7])
-	}
-	if header[11] != "IDiagSPort" {
-		t.Fatal("Incorrect header", header[11])
+	if header[6] != "IDM.Family" {
+		t.Error("Incorrect header", header[6])
 	}
 	record := strings.Split(lines[2], ",")
 	// SrcPort
-	if record[11] != "9091" {
-		t.Error(record[11])
+	if header[10] != "IDM.SockID.SPort" {
+		t.Error("Incorrect header", header[10])
+	}
+	if record[10] != "9091" {
+		t.Error(record[10])
 	}
 	// SrcIP
-	if record[13] != "192.168.14.134" {
-		t.Error(record[13])
+	if record[12] != "192.168.14.134" {
+		t.Error(record[12])
 	}
 	// Cookie
-	if record[16] != "3E8" {
+	if header[15] != "IDM.SockID.Cookie" {
+		t.Error("Incorrect header", header[15])
+	}
+	if record[15] != "3E8" {
 		t.Error(record[15])
 	}
 }

--- a/cmd/csvtool/main_test.go
+++ b/cmd/csvtool/main_test.go
@@ -22,4 +22,24 @@ func TestFileToCSV(t *testing.T) {
 		t.Errorf("%d\n%s\n%s\n:%s:\n", len(lines), lines[0], lines[1], lines[len(lines)-1])
 	}
 
+	header := strings.Split(lines[0], ",")
+	if header[7] != "IDiagFamily" {
+		t.Fatal("Incorrect header", header[7])
+	}
+	if header[11] != "IDiagSPort" {
+		t.Fatal("Incorrect header", header[11])
+	}
+	record := strings.Split(lines[2], ",")
+	// SrcPort
+	if record[11] != "9091" {
+		t.Error(record[11])
+	}
+	// SrcIP
+	if record[13] != "192.168.14.134" {
+		t.Error(record[13])
+	}
+	// Cookie
+	if record[16] != "3E8" {
+		t.Error(record[15])
+	}
 }

--- a/inetdiag/inetdiag_test.go
+++ b/inetdiag/inetdiag_test.go
@@ -9,6 +9,21 @@ import (
 )
 
 func TestSizes(t *testing.T) {
+	if unsafe.Offsetof(inetdiag.SockID{}.IDiagDPort) != 2 {
+		t.Error("Incorrect DPort offset")
+	}
+	if unsafe.Offsetof(inetdiag.SockID{}.IDiagSrc) != 4 {
+		t.Error("Incorrect Src offset")
+	}
+	if unsafe.Offsetof(inetdiag.SockID{}.IDiagDst) != 20 {
+		t.Error("Incorrect Dest offset")
+	}
+	if unsafe.Offsetof(inetdiag.SockID{}.IDiagIf) != 36 {
+		t.Error("Incorrect Interface offset")
+	}
+	if unsafe.Offsetof(inetdiag.SockID{}.IDiagCookie) != 40 {
+		t.Error("Incorrect Cookie offset")
+	}
 	if unsafe.Sizeof(inetdiag.SockID{}) != 48 {
 		t.Error("SockID wrong size", unsafe.Sizeof(inetdiag.SockID{}))
 	}

--- a/inetdiag/structs.go
+++ b/inetdiag/structs.go
@@ -109,11 +109,11 @@ func (p *Port) MarshalCSV() (string, error) {
 }
 
 // Interface encodes the SockID Interface field.
-type Interface [4]byte
+type netIF [4]byte
 
 // MarshalCSV marshals Interface to CSV
-func (i *Interface) MarshalCSV() (string, error) {
-	value := binary.BigEndian.Uint32(i[:])
+func (nif *netIF) MarshalCSV() (string, error) {
+	value := binary.BigEndian.Uint32(nif[:])
 	return fmt.Sprintf("%d", value), nil
 }
 
@@ -124,7 +124,7 @@ type SockID struct {
 	IDiagDPort  Port       `csv:"IDM.SockID.DPort"`
 	IDiagSrc    ipType     `csv:"IDM.SockID.Src"`
 	IDiagDst    ipType     `csv:"IDM.SockID.Dst"`
-	IDiagIf     Interface  `csv:"IDM.SockID.Interface"`
+	IDiagIf     netIF      `csv:"IDM.SockID.Interface"`
 	IDiagCookie cookieType `csv:"IDM.SockID.Cookie"`
 }
 

--- a/inetdiag/structs.go
+++ b/inetdiag/structs.go
@@ -93,35 +93,39 @@ func (c *cookieType) MarshalCSV() (string, error) {
 
 type ipType [16]byte
 
-type Port [2]byte
-
-func (p *Port) MarshalCSV() (string, error) {
-	value := binary.BigEndian.Uint16(p[:])
-	return fmt.Sprintf("%d", value), nil
-}
-
-type Interface [4]byte
-
-func (i *Interface) MarshalCSV() (string, error) {
-	value := binary.BigEndian.Uint32(i[:])
-	return fmt.Sprintf("%d", value), nil
-}
-
+// MarshalCSV marshals ipType to CSV
 func (ip *ipType) MarshalCSV() (string, error) {
 	netIP := (net.IP)(ip[0:16])
 	return netIP.String(), nil
 }
 
+// Port encodes a SockID Port
+type Port [2]byte
+
+// MarshalCSV marshals a Port to CSV
+func (p *Port) MarshalCSV() (string, error) {
+	value := binary.BigEndian.Uint16(p[:])
+	return fmt.Sprintf("%d", value), nil
+}
+
+// Interface encodes the SockID Interface field.
+type Interface [4]byte
+
+// MarshalCSV marshals Interface to CSV
+func (i *Interface) MarshalCSV() (string, error) {
+	value := binary.BigEndian.Uint32(i[:])
+	return fmt.Sprintf("%d", value), nil
+}
+
 // SockID is the binary linux representation of a socket, as in linux/inet_diag.h
 // Linux code comments indicate this struct uses the network byte order!!!
 type SockID struct {
-	IDiagSPort Port
-	IDiagDPort Port
-	IDiagSrc   ipType
-	IDiagDst   ipType
-	IDiagIf    Interface
-	// TODO - change this to [2]uint32 ?
-	IDiagCookie cookieType
+	IDiagSPort  Port       `csv:"IDM.SockID.SPort"`
+	IDiagDPort  Port       `csv:"IDM.SockID.DPort"`
+	IDiagSrc    ipType     `csv:"IDM.SockID.Src"`
+	IDiagDst    ipType     `csv:"IDM.SockID.Dst"`
+	IDiagIf     Interface  `csv:"IDM.SockID.Interface"`
+	IDiagCookie cookieType `csv:"IDM.SockID.Cookie"`
 }
 
 // Interface returns the interface number.
@@ -201,68 +205,68 @@ type MarkCond struct { // inet_diag_markcond
 // InetDiagMsg is the linux binary representation of a InetDiag message header, as in linux/inet_diag.h
 // Note that netlink messages use host byte ordering, unless NLA_F_NET_BYTEORDER flag is present.
 type InetDiagMsg struct {
-	IDiagFamily  uint8
-	IDiagState   uint8
-	IDiagTimer   uint8
-	IDiagRetrans uint8
-	ID           SockID
-	IDiagExpires uint32
-	IDiagRqueue  uint32
-	IDiagWqueue  uint32
-	IDiagUID     uint32
-	IDiagInode   uint32
+	IDiagFamily  uint8  `csv:"IDM.Family"`
+	IDiagState   uint8  `csv:"IDM.State"`
+	IDiagTimer   uint8  `csv:"IDM.Timer"`
+	IDiagRetrans uint8  `csv:"IDM.Retrans"`
+	ID           SockID `csv:"-"`
+	IDiagExpires uint32 `csv:"IDM.Expires"`
+	IDiagRqueue  uint32 `csv:"IDM.Rqueue"`
+	IDiagWqueue  uint32 `csv:"IDM.Wqueue"`
+	IDiagUID     uint32 `csv:"IDM.UID"`
+	IDiagInode   uint32 `csv:"IDM.Inode"`
 }
 
 // SocketMemInfo implements the struct associated with INET_DIAG_SKMEMINFO
 // Haven't found a corresponding linux struct, but the message is described
 // in https://manpages.debian.org/stretch/manpages/sock_diag.7.en.html
 type SocketMemInfo struct {
-	RmemAlloc  uint32
-	Rcvbuf     uint32
-	WmemAlloc  uint32
-	Sndbuf     uint32
-	FwdAlloc   uint32
-	WmemQueued uint32
-	Optmem     uint32
-	Backlog    uint32
-	Drops      uint32
+	RmemAlloc  uint32 `csv:"SKMemInfo.RmemAlloc"`
+	Rcvbuf     uint32 `csv:"SKMemInfo.Rcvbuf"`
+	WmemAlloc  uint32 `csv:"SKMemInfo.WmemAlloc"`
+	Sndbuf     uint32 `csv:"SKMemInfo.Sndbug"`
+	FwdAlloc   uint32 `csv:"SKMemInfo.FwdAlloc"`
+	WmemQueued uint32 `csv:"SKMemInfo.WmemQueued"`
+	Optmem     uint32 `csv:"SKMemInfo.Optmem"`
+	Backlog    uint32 `csv:"SKMemInfo.Backlog"`
+	Drops      uint32 `csv:"SKMemInfo.Drops"`
 }
 
 // MemInfo implements the struct associated with INET_DIAG_MEMINFO, corresponding with
 // linux struct inet_diag_meminfo in uapi/linux/inet_diag.h.
 type MemInfo struct {
-	Rmem uint32
-	Wmem uint32
-	Fmem uint32
-	Tmem uint32
+	Rmem uint32 `csv:"MemInfo.Rmem"`
+	Wmem uint32 `csv:"MemInfo.Wmem"`
+	Fmem uint32 `csv:"MemInfo.Fmem"`
+	Tmem uint32 `csv:"MemInfo.Tmem"`
 }
 
 // VegasInfo implements the struct associated with INET_DIAG_VEGASINFO, corresponding with
 // linux struct tcpvegas_info in uapi/linux/inet_diag.h.
 type VegasInfo struct {
-	Enabled  uint32
-	RTTCount uint32
-	RTT      uint32
-	MinRTT   uint32
+	Enabled  uint32 `csv:"Vegas.Enabled"`
+	RTTCount uint32 `csv:"Vegas.RTTCount"`
+	RTT      uint32 `csv:"Vegas.RTT"`
+	MinRTT   uint32 `csv:"Vegas.MinRTT"`
 }
 
 // DCTCPInfo implements the struct associated with INET_DIAG_DCTCPINFO attribute, corresponding with
 // linux struct tcp_dctcp_info in uapi/linux/inet_diag.h.
 type DCTCPInfo struct {
-	Enabled uint16
-	CEState uint16
-	Alpha   uint32
-	ABEcn   uint32
-	ABTot   uint32
+	Enabled uint16 `csv:"DCTCP.Enabled"`
+	CEState uint16 `csv:"DCTCP.CEState"`
+	Alpha   uint32 `csv:"DCTCP.Alpha"`
+	ABEcn   uint32 `csv:"DCTCP.ABEcn"`
+	ABTot   uint32 `csv:"DCTCP.ABTot"`
 }
 
 // BBRInfo implements the struct associated with INET_DIAG_BBRINFO attribute, corresponding with
 // linux struct tcp_bbr_info in uapi/linux/inet_diag.h.
 type BBRInfo struct {
-	Bw         int64  // Max-filtered BW (app throughput) estimate in bytes/second
-	MinRtt     uint32 // Min-filtered RTT in uSec
-	PacingGain uint32 // Pacing gain shifted left 8 bits
-	CwndGain   uint32 // Cwnd gain shifted left 8 bits
+	BW         int64  `csv:"BBR.BW"`         // Max-filtered BW (app throughput) estimate in bytes/second
+	MinRTT     uint32 `csv:"BBR.MinRTT"`     // Min-filtered RTT in uSec
+	PacingGain uint32 `csv:"BBR.PacingGain"` // Pacing gain shifted left 8 bits
+	CwndGain   uint32 `csv:"BBR.CwndGain"`   // Cwnd gain shifted left 8 bits
 }
 
 // LOCALS and PEERS contain an array of sockaddr_storage elements.

--- a/main.go
+++ b/main.go
@@ -79,7 +79,7 @@ func main() {
 	runtime.SetMutexProfileFraction(1000)
 
 	// Expose prometheus and pprof metrics on a separate port.
-	promSrv := prometheusx.MustStartPrometheus(*prometheusx.ListenAddress)
+	promSrv := prometheusx.MustServeMetrics()
 	defer promSrv.Shutdown(ctx)
 
 	if *enableTrace {

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ func init() {
 var (
 	reps        = flag.Int("reps", 0, "How many cycles should be recorded, 0 means continuous")
 	enableTrace = flag.Bool("trace", false, "Enable trace")
-	promPort    = flag.String("prom", ":9090", "Prometheus metrics export address and port. Default is ':9090'")
 	outputDir   = flag.String("output", "", "Directory in which to put the resulting tree of data.  Default is the current directory.")
 
 	ctx, cancel = context.WithCancel(context.Background())
@@ -80,7 +79,7 @@ func main() {
 	runtime.SetMutexProfileFraction(1000)
 
 	// Expose prometheus and pprof metrics on a separate port.
-	promSrv := prometheusx.MustStartPrometheus(*promPort)
+	promSrv := prometheusx.MustStartPrometheus(*prometheusx.ListenAddress)
 	defer promSrv.Shutdown(ctx)
 
 	if *enableTrace {

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -14,6 +14,8 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/m-lab/tcp-info/tcp"
+
 	"github.com/m-lab/tcp-info/inetdiag"
 	"golang.org/x/sys/unix"
 )
@@ -184,6 +186,7 @@ const (
 const (
 	lastDataSentOffset = unsafe.Offsetof(syscall.TCPInfo{}.Last_data_sent)
 	pmtuOffset         = unsafe.Offsetof(syscall.TCPInfo{}.Pmtu)
+	busytimeOffset     = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BusyTime)
 )
 
 func isLocal(addr net.IP) bool {
@@ -236,7 +239,8 @@ func (pm *ArchivalRecord) Compare(previous *ArchivalRecord) (ChangeType, error) 
 
 	// If any of the byte/segment/package counters have changed, that is what we are most
 	// interested in.
-	if 0 != bytes.Compare(a[pmtuOffset:], b[pmtuOffset:]) {
+	// NOTE: There are more fields beyond BusyTime, but for now we are ignoring them for diffing purposes.
+	if 0 != bytes.Compare(a[pmtuOffset:busytimeOffset], b[pmtuOffset:busytimeOffset]) {
 		return StateOrCounterChange, nil
 	}
 

--- a/saver/saver_test.go
+++ b/saver/saver_test.go
@@ -56,9 +56,8 @@ func msg(t *testing.T, cookie uint64, dport uint16) *netlink.ArchivalRecord {
 	}
 	for i := 0; i < 2; i++ {
 		idm.ID.IDiagDPort[i] = byte(dport & 0x0FF)
-		dport >>= 8
+		cookie >>= 8
 	}
-	//pm.SetIDM(idm)
 	t.Logf("%+v\n", mp.RawIDM)
 	return mp
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -243,11 +243,11 @@ type Snapshot struct {
 
 	Mark uint32 `csv:",omitempty"`
 
-	// Data obtained from INET_DIAG_MEMINFO.
-	MemInfo *inetdiag.MemInfo `csv:"-"`
-
 	// TCPInfo contains data from struct tcp_info.
 	TCPInfo *tcp.LinuxTCPInfo `csv:"-"`
+
+	// Data obtained from INET_DIAG_MEMINFO.
+	MemInfo *inetdiag.MemInfo `csv:"-"`
 
 	// Data obtained from INET_DIAG_SKMEMINFO.
 	SocketMem *inetdiag.SocketMemInfo `csv:"-"`

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -208,7 +208,7 @@ type Snapshot struct {
 	Timestamp time.Time
 
 	// Metadata for the connection.  Usually empty.
-	Metadata *netlink.Metadata
+	Metadata *netlink.Metadata `csv:"-"`
 
 	// Bit field indicating whether each message type was observed.
 	Observed uint32
@@ -218,15 +218,15 @@ type Snapshot struct {
 	NotFullyParsed uint32
 
 	// Info from struct inet_diag_msg, including socket_id;
-	InetDiagMsg *inetdiag.InetDiagMsg
+	InetDiagMsg *inetdiag.InetDiagMsg `csv:"-"`
 
 	// Data obtained from INET_DIAG_MEMINFO.
-	MemInfo *inetdiag.MemInfo
+	MemInfo *inetdiag.MemInfo `csv:"-"`
 
 	// TCPInfo contains data from struct tcp_info.
-	TCPInfo *tcp.LinuxTCPInfo
+	TCPInfo *tcp.LinuxTCPInfo `csv:"-"`
 
-	VegasInfo *inetdiag.VegasInfo
+	VegasInfo *inetdiag.VegasInfo `csv:"-"`
 
 	// From INET_DIAG_CONG message.
 	CongestionAlgorithm string
@@ -237,18 +237,18 @@ type Snapshot struct {
 	TClass uint8
 
 	// Data obtained from INET_DIAG_SKMEMINFO.
-	SocketMem *inetdiag.SocketMemInfo
+	SocketMem *inetdiag.SocketMemInfo `csv:"-"`
 
 	// TODO Do we need to record present and zero, vs absent?
 	Shutdown uint8
 
-	DCTCPInfo *inetdiag.DCTCPInfo
+	DCTCPInfo *inetdiag.DCTCPInfo `csv:"-"`
 
 	// From INET_DIAG_PROTOCOL message.
 	// TODO Do we need to record present and zero, vs absent?
 	Protocol inetdiag.Protocol
 
-	BBRInfo *inetdiag.BBRInfo
+	BBRInfo *inetdiag.BBRInfo `csv:"-"`
 
 	Mark uint32
 }

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -73,7 +73,7 @@ func Decode(ar *netlink.ArchivalRecord) (*Snapshot, error) {
 		case inetdiag.INET_DIAG_BBRINFO:
 			result.BBRInfo, ok = rta.toBBRInfo()
 		case inetdiag.INET_DIAG_CLASS_ID:
-			log.Println("CLASS_ID not handled", len(rta))
+			result.ClassID, ok = rta.toClassID()
 		case inetdiag.INET_DIAG_MD5SIG:
 			log.Println("MD5SIGnot handled", len(rta))
 		default:
@@ -162,6 +162,11 @@ func (raw RouteAttrValue) toTCLASS() (uint8, bool) {
 	return raw.toUint8()
 }
 
+// toTCLASS marshals the TCP Traffic Class octet.  See https://tools.ietf.org/html/rfc3168
+func (raw RouteAttrValue) toClassID() (uint8, bool) {
+	return raw.toUint8()
+}
+
 // toSockMemInfo maps the raw RouteAttrValue onto a SockMemInfo.
 // For older data, it may have to copy the bytes.
 func (raw RouteAttrValue) toSockMemInfo() (*inetdiag.SocketMemInfo, bool) {
@@ -233,8 +238,9 @@ type Snapshot struct {
 
 	// See https://tools.ietf.org/html/rfc3168
 	// TODO Do we need to record whether these are present and zero, vs absent?
-	TOS    uint8 `csv:",omitempty"`
-	TClass uint8 `csv:",omitempty"`
+	TOS     uint8 `csv:",omitempty"`
+	TClass  uint8 `csv:",omitempty"`
+	ClassID uint8 `csv:",omitempty"`
 
 	// Data obtained from INET_DIAG_SKMEMINFO.
 	SocketMem *inetdiag.SocketMemInfo `csv:"-"`

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -215,7 +215,7 @@ type Snapshot struct {
 
 	// Bit field indicating whether any message type was NOT fully parsed.
 	// TODO - populate this field if any message is ignored, or not fully parsed.
-	NotFullyParsed uint32
+	NotFullyParsed uint32 `csv:",omitempty"`
 
 	// Info from struct inet_diag_msg, including socket_id;
 	InetDiagMsg *inetdiag.InetDiagMsg `csv:"-"`
@@ -229,28 +229,28 @@ type Snapshot struct {
 	VegasInfo *inetdiag.VegasInfo `csv:"-"`
 
 	// From INET_DIAG_CONG message.
-	CongestionAlgorithm string
+	CongestionAlgorithm string `csv:",omitempty"`
 
 	// See https://tools.ietf.org/html/rfc3168
 	// TODO Do we need to record whether these are present and zero, vs absent?
-	TOS    uint8
-	TClass uint8
+	TOS    uint8 `csv:",omitempty"`
+	TClass uint8 `csv:",omitempty"`
 
 	// Data obtained from INET_DIAG_SKMEMINFO.
 	SocketMem *inetdiag.SocketMemInfo `csv:"-"`
 
 	// TODO Do we need to record present and zero, vs absent?
-	Shutdown uint8
+	Shutdown uint8 `csv:",omitempty"`
 
 	DCTCPInfo *inetdiag.DCTCPInfo `csv:"-"`
 
 	// From INET_DIAG_PROTOCOL message.
 	// TODO Do we need to record present and zero, vs absent?
-	Protocol inetdiag.Protocol
+	Protocol inetdiag.Protocol `csv:",omitempty"`
 
 	BBRInfo *inetdiag.BBRInfo `csv:"-"`
 
-	Mark uint32
+	Mark uint32 `csv:",omitempty"`
 }
 
 // ConnectionLog contains a Metadata and slice of Snapshots.

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -225,14 +225,6 @@ type Snapshot struct {
 	// Info from struct inet_diag_msg, including socket_id;
 	InetDiagMsg *inetdiag.InetDiagMsg `csv:"-"`
 
-	// Data obtained from INET_DIAG_MEMINFO.
-	MemInfo *inetdiag.MemInfo `csv:"-"`
-
-	// TCPInfo contains data from struct tcp_info.
-	TCPInfo *tcp.LinuxTCPInfo `csv:"-"`
-
-	VegasInfo *inetdiag.VegasInfo `csv:"-"`
-
 	// From INET_DIAG_CONG message.
 	CongestionAlgorithm string `csv:",omitempty"`
 
@@ -242,21 +234,27 @@ type Snapshot struct {
 	TClass  uint8 `csv:",omitempty"`
 	ClassID uint8 `csv:",omitempty"`
 
-	// Data obtained from INET_DIAG_SKMEMINFO.
-	SocketMem *inetdiag.SocketMemInfo `csv:"-"`
-
 	// TODO Do we need to record present and zero, vs absent?
 	Shutdown uint8 `csv:",omitempty"`
-
-	DCTCPInfo *inetdiag.DCTCPInfo `csv:"-"`
 
 	// From INET_DIAG_PROTOCOL message.
 	// TODO Do we need to record present and zero, vs absent?
 	Protocol inetdiag.Protocol `csv:",omitempty"`
 
-	BBRInfo *inetdiag.BBRInfo `csv:"-"`
-
 	Mark uint32 `csv:",omitempty"`
+
+	// Data obtained from INET_DIAG_MEMINFO.
+	MemInfo *inetdiag.MemInfo `csv:"-"`
+
+	// TCPInfo contains data from struct tcp_info.
+	TCPInfo *tcp.LinuxTCPInfo `csv:"-"`
+
+	// Data obtained from INET_DIAG_SKMEMINFO.
+	SocketMem *inetdiag.SocketMemInfo `csv:"-"`
+
+	VegasInfo *inetdiag.VegasInfo `csv:"-"`
+	DCTCPInfo *inetdiag.DCTCPInfo `csv:"-"`
+	BBRInfo   *inetdiag.BBRInfo   `csv:"-"`
 }
 
 // ConnectionLog contains a Metadata and slice of Snapshots.

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -73,6 +73,10 @@ func TestDecodeArchiveRecords(t *testing.T) {
 
 		observed |= snap.Observed
 		parsed++
+
+		if parsed > 0 && snap.InetDiagMsg == nil {
+			t.Fatal("Missing IDM", snap)
+		}
 	}
 
 	if observed != (1<<inetdiag.INET_DIAG_MAX)-1 {

--- a/tcp/tcpinfo.go
+++ b/tcp/tcpinfo.go
@@ -55,72 +55,72 @@ func (x State) String() string {
 // LinuxTCPInfo is the linux defined structure returned in RouteAttr DIAG_INFO messages.
 // It corresponds to the struct tcp_info in include/uapi/linux/tcp.h
 type LinuxTCPInfo struct {
-	State       uint8
-	CAState     uint8
-	Retransmits uint8
-	Probes      uint8
-	Backoff     uint8
-	Options     uint8
-	WScale      uint8 //snd_wscale : 4, tcpi_rcv_wscale : 4;
-	AppLimited  uint8 //delivery_rate_app_limited:1;
+	State       uint8 `csv:"TCP.State"`
+	CAState     uint8 `csv:"TCP.CAState"`
+	Retransmits uint8 `csv:"TCP.Retransmits"`
+	Probes      uint8 `csv:"TCP.Probes"`
+	Backoff     uint8 `csv:"TCP.Backoff"`
+	Options     uint8 `csv:"TCP.Options"`
+	WScale      uint8 `csv:"TCP.WScale"`     //snd_wscale : 4, tcpi_rcv_wscale : 4;
+	AppLimited  uint8 `csv:"TCP.AppLimited"` //delivery_rate_app_limited:1;
 
-	RTO    uint32 // offset 8
-	ATO    uint32
-	SndMSS uint32
-	RcvMSS uint32
+	RTO    uint32 `csv:"TCP.RTO"` // offset 8
+	ATO    uint32 `csv:"TCP.ATO"`
+	SndMSS uint32 `csv:"TCP.SndMSS"`
+	RcvMSS uint32 `csv:"TCP.RcvMSS"`
 
-	Unacked uint32 // offset 24
-	Sacked  uint32
-	Lost    uint32
-	Retrans uint32
-	Fackets uint32
+	Unacked uint32 `csv:"TCP.Unacked"` // offset 24
+	Sacked  uint32 `csv:"TCP.Sacked"`
+	Lost    uint32 `csv:"TCP.Lost"`
+	Retrans uint32 `csv:"TCP.Retrans"`
+	Fackets uint32 `csv:"TCP.Fackets"`
 
 	/* Times. */
 	// These seem to be elapsed time, so they increase on almost every sample.
 	// We can probably use them to get more info about intervals between samples.
-	LastDataSent uint32 // offset 44
-	LastAckSent  uint32 /* Not remembered, sorry. */ // offset 48
-	LastDataRecv uint32 // offset 52
-	LastAckRecv  uint32 // offset 56
+	LastDataSent uint32 `csv:"TCP.LastDataSent"` // offset 44
+	LastAckSent  uint32 `csv:"TCP.LastAckSent"`  /* Not remembered, sorry. */ // offset 48
+	LastDataRecv uint32 `csv:"TCP.LastDataRecv"` // offset 52
+	LastAckRecv  uint32 `csv:"TCP.LastDataRecv"` // offset 56
 
 	/* Metrics. */
-	PMTU        uint32
-	RcvSsThresh uint32
-	RTT         uint32
-	RTTVar      uint32
-	SndSsThresh uint32
-	SndCwnd     uint32
-	AdvMSS      uint32
-	Reordering  uint32
+	PMTU        uint32 `csv:"TCP.PMTU"`
+	RcvSsThresh uint32 `csv:"TCP.RcvSsThresh"`
+	RTT         uint32 `csv:"TCP.RTT"`
+	RTTVar      uint32 `csv:"TCP.RTTVar"`
+	SndSsThresh uint32 `csv:"TCP.SndSsThresh"`
+	SndCwnd     uint32 `csv:"TCP.SndCwnd"`
+	AdvMSS      uint32 `csv:"TCP.AdvMSS"`
+	Reordering  uint32 `csv:"TCP.Reordering"`
 
-	RcvRTT   uint32
-	RcvSpace uint32
+	RcvRTT   uint32 `csv:"TCP.RcvRTT"`
+	RcvSpace uint32 `csv:"TCP.RcvSpace"`
 
-	TotalRetrans uint32
+	TotalRetrans uint32 `csv:"TCP.TotalRetrans"`
 
-	PacingRate    int64  // This is often -1, so better for it to be signed
-	MaxPacingRate int64  // This is often -1, so better to be signed.
-	BytesAcked    uint64 /* RFC4898 tcpEStatsAppHCThruOctetsAcked */
-	BytesReceived uint64 /* RFC4898 tcpEStatsAppHCThruOctetsReceived */
-	SegsOut       uint32 /* RFC4898 tcpEStatsPerfSegsOut */
-	SegsIn        uint32 /* RFC4898 tcpEStatsPerfSegsIn */
+	PacingRate    int64  `csv:"TCP.PacingRate"`    // This is often -1, so better for it to be signed
+	MaxPacingRate int64  `csv:"TCP.MaxPacingRate"` // This is often -1, so better to be signed.
+	BytesAcked    uint64 `csv:"TCP.BytesAcked"`    /* RFC4898 tcpEStatsAppHCThruOctetsAcked */
+	BytesReceived uint64 `csv:"TCP.BytesReceived"` /* RFC4898 tcpEStatsAppHCThruOctetsReceived */
+	SegsOut       uint32 `csv:"TCP.SegsOut"`       /* RFC4898 tcpEStatsPerfSegsOut */
+	SegsIn        uint32 `csv:"TCP.SegsIn"`        /* RFC4898 tcpEStatsPerfSegsIn */
 
-	NotsentBytes uint32
-	MinRTT       uint32
-	DataSegsIn   uint32 /* RFC4898 tcpEStatsDataSegsIn */
-	DataSegsOut  uint32 /* RFC4898 tcpEStatsDataSegsOut */
+	NotsentBytes uint32 `csv:"TCP.NotsentBytes"`
+	MinRTT       uint32 `csv:"TCP.MinRTT"`
+	DataSegsIn   uint32 `csv:"TCP.DataSegsIn"`  /* RFC4898 tcpEStatsDataSegsIn */
+	DataSegsOut  uint32 `csv:"TCP.DataSegsOut"` /* RFC4898 tcpEStatsDataSegsOut */
 
-	DeliveryRate uint64
+	DeliveryRate uint64 `csv:"TCP.DeliveryRate"`
 
-	BusyTime      int64 /* Time (usec) busy sending data */
-	RWndLimited   int64 /* Time (usec) limited by receive window */
-	SndBufLimited int64 /* Time (usec) limited by send buffer */
+	BusyTime      int64 `csv:"TCP.BusyTime"`      /* Time (usec) busy sending data */
+	RWndLimited   int64 `csv:"TCP.RWndLimited"`   /* Time (usec) limited by receive window */
+	SndBufLimited int64 `csv:"TCP.SndBufLimited"` /* Time (usec) limited by send buffer */
 
-	Delivered   uint32
-	DeliveredCE uint32
+	Delivered   uint32 `csv:"TCP.Delivered"`
+	DeliveredCE uint32 `csv:"TCP.DeliveredCE"`
 
-	BytesSent    uint64 /* RFC4898 tcpEStatsPerfHCDataOctetsOut */
-	BytesRetrans uint64 /* RFC4898 tcpEStatsPerfOctetsRetrans */
-	DSackDups    uint32 /* RFC4898 tcpEStatsStackDSACKDups */
-	ReordSeen    uint32 /* reordering events seen */
+	BytesSent    uint64 `csv:"TCP.BytesSent"`    /* RFC4898 tcpEStatsPerfHCDataOctetsOut */
+	BytesRetrans uint64 `csv:"TCP.BytesRetrans"` /* RFC4898 tcpEStatsPerfOctetsRetrans */
+	DSackDups    uint32 `csv:"TCP.DSackDups"`    /* RFC4898 tcpEStatsStackDSACKDups */
+	ReordSeen    uint32 `csv:"TCP.ReordSeen"`    /* reordering events seen */
 }


### PR DESCRIPTION
1. Defines types and adds proper marshaling for all IDiagMsg fields.
  Cookie: hex encoded uint64
  IP addresses: ipv4 or ipv6 string
2. Adds csv tags for all snapshot struct fields, to improve the header readability.
3. Adjusts and improves tests 

ALSO:
4. Restricts the diff detection to avoid BusyTime field.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/77)
<!-- Reviewable:end -->
