### PR TITLE
separate metadata from snapshots

### DIFF
--- a/cmd/csvtool/main.go
+++ b/cmd/csvtool/main.go
@@ -54,8 +54,8 @@ func main() {
 	defer source.Close()
 
 	arReader := netlink.NewArchiveReader(source)
-	meta, snaps, err := snapshot.LoadAll(arReader)
-	log.Println("Metadata:", meta)
+	// Ignore the metadata for now.
+	_, snaps, err := snapshot.LoadAll(arReader)
 	rtx.Must(err, "Could not read snapshots")
 	rtx.Must(toCSV(snaps, os.Stdout), "Could not convert input to CSV")
 }

--- a/cmd/csvtool/main.go
+++ b/cmd/csvtool/main.go
@@ -25,18 +25,7 @@ var (
 	logFatal = log.Fatal
 )
 
-// parses ArchiveRecords from the reader and writes CSV to the writer
-func readSnapshots(rdr io.Reader) ([]*snapshot.Snapshot, error) {
-	// Read input from provided reader.
-	arReader := netlink.NewArchiveReader(rdr)
-	return snapshot.LoadAll(arReader)
-}
-
 func toCSV(snapshots []*snapshot.Snapshot, wtr io.Writer) error {
-	if len(snapshots) > 0 && snapshots[0].Metadata == nil {
-		// Add empty Metadata.
-		snapshots[0].Metadata = &netlink.Metadata{}
-	}
 	return gocsv.Marshal(snapshots, wtr)
 }
 
@@ -64,7 +53,9 @@ func main() {
 	}
 	defer source.Close()
 
-	snaps, err := readSnapshots(source)
+	arReader := netlink.NewArchiveReader(source)
+	meta, snaps, err := snapshot.LoadAll(arReader)
+	log.Println("Metadata:", meta)
 	rtx.Must(err, "Could not read snapshots")
 	rtx.Must(toCSV(snaps, os.Stdout), "Could not convert input to CSV")
 }

--- a/cmd/csvtool/main_test.go
+++ b/cmd/csvtool/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/tcp-info/netlink"
 	"github.com/m-lab/tcp-info/snapshot"
 )
 
@@ -61,7 +62,7 @@ func TestFileToCSV(t *testing.T) {
 	src, err := openFile("testdata/ndt-jdczh_1553815964_00000000000003E8.00183.jsonl.zst")
 	rtx.Must(err, "Could not open file")
 	buf := bytes.NewBuffer(nil)
-	snaps, err := readSnapshots(src)
+	_, snaps, err := snapshot.LoadAll(netlink.NewArchiveReader(src))
 	rtx.Must(err, "Could not read test data")
 
 	err = toCSV(snaps, buf)
@@ -78,35 +79,28 @@ func TestFileToCSV(t *testing.T) {
 	}
 
 	header := strings.Split(lines[0], ",")
-	if header[6] != "IDM.Family" {
-		t.Error("Incorrect header", header[6])
+	if header[3] != "IDM.Family" {
+		t.Error("Incorrect header", header[3])
 	}
 	record := strings.Split(lines[2], ",")
 	// SrcPort
-	if header[10] != "IDM.SockID.SPort" {
-		t.Error("Incorrect header", header[10])
+	if header[7] != "IDM.SockID.SPort" {
+		t.Error("Incorrect header", header[7])
 	}
-	if record[10] != "9091" {
-		t.Error(record[10])
+	if record[7] != "9091" {
+		t.Error(record[7])
 	}
 	// SrcIP
-	if record[12] != "192.168.14.134" {
-		t.Error(record[12])
+	if record[9] != "192.168.14.134" {
+		t.Error(record[9])
 	}
 	// Cookie
-	if header[15] != "IDM.SockID.Cookie" {
-		t.Error("Incorrect header", header[15])
+	if header[12] != "IDM.SockID.Cookie" {
+		t.Error("Incorrect header", header[12])
 	}
-	if record[15] != "3E8" {
-		t.Error(record[15])
+	if record[12] != "3E8" {
+		t.Error(record[12])
 	}
 }
 
-func TestToCSVFillsInEmptyMetadata(t *testing.T) {
-	snap := snapshot.Snapshot{}
-	buf := bytes.NewBuffer(nil)
-	rtx.Must(toCSV([]*snapshot.Snapshot{&snap}, buf), "Could not convert")
-	if snap.Metadata == nil {
-		t.Error("Failed to fill in empty metadata")
-	}
-}
+

--- a/snapshot/snapshot_test.go
+++ b/snapshot/snapshot_test.go
@@ -34,7 +34,7 @@ func TestRawReader(t *testing.T) {
 	var observed uint32
 
 	for {
-		s, err := snReader.Next()
+		_, s, err := snReader.Next()
 		if err == io.EOF {
 			break
 		}
@@ -65,7 +65,7 @@ func TestDecodeArchiveRecords(t *testing.T) {
 	var observed uint32
 
 	for {
-		snap, err := snapReader.Next()
+		_, snap, err := snapReader.Next()
 		if err == io.EOF {
 			break
 		}
@@ -102,7 +102,7 @@ func TestBCNFile(t *testing.T) {
 	var problems uint32
 
 	for {
-		snap, err := snapReader.Next()
+		_, snap, err := snapReader.Next()
 		if err == io.EOF {
 			break
 		}
@@ -136,7 +136,7 @@ func TestLoadAll(t *testing.T) {
 	defer rdr.Close()
 	arReader := netlink.NewArchiveReader(rdr)
 
-	all, err := snapshot.LoadAll(arReader)
+	meta, all, err := snapshot.LoadAll(arReader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,4 +144,8 @@ func TestLoadAll(t *testing.T) {
 	if len(all) != 151 {
 		t.Error("Wrong count:", len(all))
 	}
+	if meta == nil {
+		t.Error("No metadata")
+	}
+
 }


### PR DESCRIPTION
In BQ, we want to collect all snapshots as a repeated field in a single row for each test.  This separates the metadata from the snapshots, so that it can be placed in the top level fields of the row.

This means that the metadata will no longer appear in the CVS rows.  To make up for this, the CSV tool will print metadata before the CSV header and snapshot data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/87)
<!-- Reviewable:end -->
