### PR TITLE
Tries to create the directory specified by the --output flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func main() {
 	flagx.ArgsFromEnv(flag.CommandLine)
 
 	if *outputDir != "" {
+		rtx.PanicOnError(os.MkdirAll(*outputDir, 0755), "Could not create the output dir %s", *outputDir)
 		rtx.Must(os.Chdir(*outputDir), "Could not change to the directory %s", *outputDir)
 	}
 


### PR DESCRIPTION
[A recent PR in the k8s-support repo](https://github.com/m-lab/k8s-support/pull/231) leaves the onus of creating the data directory on the experiment containers.  We found that this breaks tcp-info, which assumes that the output data directory specified by `--output` already exists (which it did before the linked PR above). This PR creates the directory before trying to `cd` into it.

I _believe_ that `os.MkdirAll` will be idempotent. [The docs for the function](https://golang.org/pkg/os/#MkdirAll) state:
> If path is already a directory, MkdirAll does nothing and returns nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/92)
<!-- Reviewable:end -->
