### PR TITLE
Raw message channel

### DIFF
--- a/collector/collector_darwin.go
+++ b/collector/collector_darwin.go
@@ -7,9 +7,8 @@ import (
 	"github.com/m-lab/tcp-info/saver"
 )
 
-// No code, but needed for compiling.
-
-func Run(ctx context.Context, reps int, svrChan chan<- []*netlink.ArchivalRecord, cl saver.CacheLogger, skipLocal bool) (localCount, errCount int) {
+// Run does nothing, but needed for compiling on Darwin.
+func Run(ctx context.Context, reps int, svrChan chan<- netlink.MessageBlock, cl saver.CacheLogger, skipLocal bool) (localCount, errCount int) {
 	// Does notihg in Darwin
 	return 0, 0
 }

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 	// Make the saver and construct the message channel, buffering up to 2 batches
 	// of messages without stalling producer. We may want to increase the buffer if
 	// we observe main() stalling.
-	svrChan := make(chan []*netlink.ArchivalRecord, 2)
+	svrChan := make(chan netlink.MessageBlock, 2)
 	svr := saver.NewSaver("host", "pod", 3)
 	go svr.MessageSaverLoop(svrChan)
 

--- a/netlink/archival-record.go
+++ b/netlink/archival-record.go
@@ -136,8 +136,8 @@ const (
 	lastDataSentOffset  = unsafe.Offsetof(tcp.LinuxTCPInfo{}.LastDataSent)
 	pmtuOffset          = unsafe.Offsetof(tcp.LinuxTCPInfo{}.PMTU)
 	busytimeOffset      = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BusyTime)
-	bytesSentOffset     = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BytesSent)
-	bytesReceivedOffset = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BytesReceived)
+	bytesReceivedOffset = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BytesReceived) // 128
+	bytesSentOffset     = unsafe.Offsetof(tcp.LinuxTCPInfo{}.BytesSent)     // 200
 )
 
 func isLocal(addr net.IP) bool {
@@ -339,7 +339,8 @@ func (pm *ArchivalRecord) GetStats() (int64, int64) {
 		return 0, 0
 	}
 	raw := pm.Attributes[inetdiag.INET_DIAG_INFO]
-	if len(raw) < int(bytesSentOffset+4) {
+	// Ensure the array contains both uint64 fields.
+	if len(raw) < int(bytesSentOffset+8) || len(raw) < int(bytesReceivedOffset+8) {
 		return 0, 0
 	}
 	s := *(*int64)(unsafe.Pointer(&raw[bytesSentOffset]))

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -1,0 +1,12 @@
+package netlink
+
+import "time"
+
+// MessageBlock contains timestamps and message arrays for v4 and v6 from a single collection cycle.
+type MessageBlock struct {
+	V4Time     time.Time         // Time at which netlink message block was received.
+	V4Messages []*NetlinkMessage // Array of raw messages.
+
+	V6Time     time.Time
+	V6Messages []*NetlinkMessage
+}

--- a/saver/saver_test.go
+++ b/saver/saver_test.go
@@ -5,15 +5,22 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/tcp-info/inetdiag"
+	"github.com/m-lab/tcp-info/metrics"
 	"github.com/m-lab/tcp-info/netlink"
 	"github.com/m-lab/tcp-info/saver"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // TODO Tests:
@@ -35,7 +42,67 @@ func dump(t *testing.T, mp *netlink.ArchivalRecord) {
 	}
 }
 
-func msg(t *testing.T, cookie uint64, dport uint16) *netlink.ArchivalRecord {
+type TestMsg struct {
+	netlink.NetlinkMessage
+}
+
+func (msg *TestMsg) copy() *TestMsg {
+	out := TestMsg{}
+	out.Header = msg.Header
+	copy(out.Data, msg.Data)
+	return &out
+}
+
+func (msg *TestMsg) setCookie(cookie uint64) *TestMsg {
+	raw, _ := inetdiag.SplitInetDiagMsg(msg.Data)
+	if raw == nil {
+		panic("setCookie failed")
+	}
+	idm, err := raw.Parse()
+	if err != nil {
+		panic("setCookie failed")
+	}
+	for i := 0; i < 8; i++ {
+		idm.ID.IDiagCookie[i] = byte(cookie & 0x0FF)
+		cookie >>= 8
+	}
+
+	return msg
+}
+func (msg *TestMsg) setDPort(dport uint16) *TestMsg {
+	raw, _ := inetdiag.SplitInetDiagMsg(msg.Data)
+	if raw == nil {
+		panic("setCookie failed")
+	}
+	idm, err := raw.Parse()
+	if err != nil {
+		panic("setCookie failed")
+	}
+	for i := 0; i < 2; i++ {
+		idm.ID.IDiagDPort[i] = byte(dport & 0x0FF)
+		dport >>= 8
+	}
+
+	return msg
+}
+
+func (msg *TestMsg) setByte(offset int, value byte) *TestMsg {
+	ar, err := netlink.MakeArchivalRecord(&msg.NetlinkMessage, true)
+	if err != nil {
+		panic("")
+	}
+
+	if len(ar.Attributes) <= inetdiag.INET_DIAG_INFO {
+		panic("")
+	}
+
+	ar.Attributes[inetdiag.INET_DIAG_INFO][offset] = value
+
+	return msg
+}
+
+func msg(t *testing.T, cookie uint64, dport uint16) *TestMsg {
+	// TODO - this is an incomplete message and should be replaced with a full message.
 	var json1 = `{"Header":{"Len":356,"Type":20,"Flags":2,"Seq":1,"Pid":148940},"Data":"CgEAAOpWE6cmIAAAEAMEFbM+nWqBv4ehJgf4sEANDAoAAAAAAAAAgQAAAAAdWwAAAAAAAAAAAAAAAAAAAAAAAAAAAAC13zIBBQAIAAAAAAAFAAUAIAAAAAUABgAgAAAAFAABAAAAAAAAAAAAAAAAAAAAAAAoAAcAAAAAAICiBQAAAAAAALQAAAAAAAAAAAAAAAAAAAAAAAAAAAAArAACAAEAAAAAB3gBQIoDAECcAABEBQAAuAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUCEAAAAAAAAgIQAAQCEAANwFAACsywIAJW8AAIRKAAD///9/CgAAAJQFAAADAAAALMkAAIBwAAAAAAAALnUOAAAAAAD///////////ayBAAAAAAASfQPAAAAAADMEQAANRMAAAAAAABiNQAAxAsAAGMIAABX5AUAAAAAAAoABABjdWJpYwAAAA=="}`
 	nm := netlink.NetlinkMessage{}
 	err := json.Unmarshal([]byte(json1), &nm)
@@ -43,22 +110,11 @@ func msg(t *testing.T, cookie uint64, dport uint16) *netlink.ArchivalRecord {
 		t.Log(err)
 		return nil
 	}
-	mp, err := netlink.MakeArchivalRecord(&nm, true)
-	if err != nil {
-		t.Log(err)
-		return nil
-	}
-	idm, err := mp.RawIDM.Parse()
-	for i := 0; i < 8; i++ {
-		idm.ID.IDiagCookie[i] = byte(cookie & 0x0FF)
-		cookie >>= 8
-	}
-	for i := 0; i < 2; i++ {
-		idm.ID.IDiagDPort[i] = byte(dport & 0x0FF)
-		cookie >>= 8
-	}
-	t.Logf("%+v\n", mp.RawIDM)
-	return mp
+
+	msg := &TestMsg{nm}
+
+	msg = msg.setCookie(cookie).setDPort(dport)
+	return msg
 }
 
 func verifySizeBetween(t *testing.T, minSize, maxSize int64, pattern string) {
@@ -78,6 +134,29 @@ func verifySizeBetween(t *testing.T, minSize, maxSize int64, pattern string) {
 	}
 }
 
+func histContains(m prometheus.Metric, s string) bool {
+	var mm dto.Metric
+	m.Write(&mm)
+	h := mm.GetHistogram()
+	if h == nil {
+		log.Println(h)
+		return false
+	}
+	return strings.Contains(h.String(), s)
+}
+
+func counterValue(m prometheus.Metric) float64 {
+	var mm dto.Metric
+	m.Write(&mm)
+	ctr := mm.GetCounter()
+	if ctr == nil {
+		log.Println(mm.GetUntyped())
+		return math.Inf(-1)
+	}
+
+	return *ctr.Value
+}
+
 func TestBasic(t *testing.T) {
 	dir, err := ioutil.TempDir("", "tcp-info_saver_TestBasic")
 	rtx.Must(err, "Could not create tempdir")
@@ -90,40 +169,51 @@ func TestBasic(t *testing.T) {
 		rtx.Must(os.Chdir(oldDir), "Could not switch back to %s", oldDir)
 	}()
 	svr := saver.NewSaver("foo", "bar", 1)
-	svrChan := make(chan []*netlink.ArchivalRecord, 0) // no buffering
+	svrChan := make(chan netlink.MessageBlock, 0) // no buffering
 	go svr.MessageSaverLoop(svrChan)
 
+	date := time.Date(2018, 02, 06, 11, 12, 13, 0, time.UTC)
+	mb := netlink.MessageBlock{V4Time: date, V6Time: date}
 	// This round just initializes the cache.
-	m1 := []*netlink.ArchivalRecord{msg(t, 11234, 11234), msg(t, 235, 235)}
-	dump(t, m1[0])
-	svrChan <- m1
+	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 11234, 11234).NetlinkMessage, &msg(t, 235, 235).NetlinkMessage}
+	//dump(t, m1[0])
+	svrChan <- mb
 
-	// This should NOT write to file, because nothing changed
-	m2 := []*netlink.ArchivalRecord{msg(t, 1234, 1234), msg(t, 234, 234)}
-	svrChan <- m2
+	// // This should NOT write to file, because nothing changed
+	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).NetlinkMessage, &msg(t, 234, 234).NetlinkMessage}
+	svrChan <- mb
 
-	// This changes the first connection, and ends the second connection.
-	m3 := []*netlink.ArchivalRecord{msg(t, 1234, 1234)}
-	m3[0].Attributes[inetdiag.INET_DIAG_INFO][20] = 127
-	svrChan <- m3
+	// // This changes the first connection, and ends the second connection.
+	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).setByte(20, 127).NetlinkMessage}
+	svrChan <- mb
 
-	// This changes the first connecti:on again.
-	m4 := []*netlink.ArchivalRecord{msg(t, 1234, 1234)}
-	m3[0].Attributes[inetdiag.INET_DIAG_INFO][20] = 127
-	m4[0].Attributes[inetdiag.INET_DIAG_INFO][105] = 127
-	svrChan <- m4
+	// // This changes the first connecti:on again.
+	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).setByte(20, 127).setByte(105, 127).NetlinkMessage}
+	svrChan <- mb
 
-	m5 := []*netlink.ArchivalRecord{msg(t, 1234, 1234)}
-	svrChan <- m5
+	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).NetlinkMessage}
+	svrChan <- mb
+
 	// Force close all the files.
 	close(svrChan)
 	svr.Done.Wait()
+
+	c := make(chan prometheus.Metric, 10)
+
+	// We should have seen 4 different connections.
+	metrics.NewFileCount.Collect(c)
+	fc := <-c
+	if counterValue(fc) != 4 {
+		t.Error("Expected 4, saw ", counterValue(fc))
+	}
+	close(c)
+
 	// We have to use a range-based size verification because different versions of
 	// zstd have slightly different compression ratios.
 	// The min/max criteria are based on zstd 1.3.8.
 	// These may change with different zstd versions.
-	verifySizeBetween(t, 350, 450, "0001/01/01/*_0000000000002BE2.00000.jsonl.zst")
-	verifySizeBetween(t, 350, 450, "0001/01/01/*_00000000000000EB.00000.jsonl.zst")
+	verifySizeBetween(t, 350, 450, "2018/02/06/*_0000000000002BE2.00000.jsonl.zst")
+	verifySizeBetween(t, 350, 450, "2018/02/06/*_00000000000000EB.00000.jsonl.zst")
 }
 
 // If this compiles, the "test" passes

--- a/saver/saver_test.go
+++ b/saver/saver_test.go
@@ -176,18 +176,17 @@ func TestBasic(t *testing.T) {
 	mb := netlink.MessageBlock{V4Time: date, V6Time: date}
 	// This round just initializes the cache.
 	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 11234, 11234).NetlinkMessage, &msg(t, 235, 235).NetlinkMessage}
-	//dump(t, m1[0])
 	svrChan <- mb
 
-	// // This should NOT write to file, because nothing changed
+	// This should NOT write to file, because nothing changed
 	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).NetlinkMessage, &msg(t, 234, 234).NetlinkMessage}
 	svrChan <- mb
 
-	// // This changes the first connection, and ends the second connection.
+	// This changes the first connection, and ends the second connection.
 	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).setByte(20, 127).NetlinkMessage}
 	svrChan <- mb
 
-	// // This changes the first connecti:on again.
+	// This changes the first connection again.
 	mb.V4Messages = []*netlink.NetlinkMessage{&msg(t, 1234, 1234).setByte(20, 127).setByte(105, 127).NetlinkMessage}
 	svrChan <- mb
 


### PR DESCRIPTION
This is part of m-lab/dev-tracker#322.

This makes several changes to reduce the work done by the collector, and allow for more robust testing.

It introduces netlink.MessageBlock, and then uses a MessageBlock channel to pass work to the saver, instead of an array of ArchivalRecord.   The interpretation of raw netlink messages is then done in the saver, instead of in the collector.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/95)
<!-- Reviewable:end -->
