### PR TITLE
Use a standard flag for the event socket.

### DIFF
--- a/eventsocket/client.go
+++ b/eventsocket/client.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"flag"
 	"log"
 	"net"
 	"strings"
@@ -11,6 +12,13 @@ import (
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/tcp-info/inetdiag"
+)
+
+var (
+	// Filename is a command-line flag holding the name of the unix-domain
+	// socket that should be used by the client and server. It is put here in an
+	// attempt to have just one standard flag name.
+	Filename = flag.String("tcpinfo.eventsocket", "", "The filename of the unix-domain socket on which events are served.")
 )
 
 // Handler is the interface that all interested users of the event socket

--- a/main.go
+++ b/main.go
@@ -64,7 +64,6 @@ var (
 	reps        = flag.Int("reps", 0, "How many cycles should be recorded, 0 means continuous")
 	enableTrace = flag.Bool("trace", false, "Enable trace")
 	outputDir   = flag.String("output", "", "Directory in which to put the resulting tree of data.  Default is the current directory.")
-	eventSocket = flag.String("eventsocket", "", "The filename of the unix-domain socket on which to serve events.")
 
 	ctx, cancel = context.WithCancel(context.Background())
 )
@@ -95,10 +94,10 @@ func main() {
 
 	// Make and start the event server.
 	eventSrv := eventsocket.NullServer()
-	if *eventSocket != "" {
-		eventSrv = eventsocket.New(*eventSocket)
+	if *eventsocket.Filename != "" {
+		eventSrv = eventsocket.New(*eventsocket.Filename)
 	}
-	rtx.Must(eventSrv.Listen(), "Could not listen on", *eventSocket)
+	rtx.Must(eventSrv.Listen(), "Could not listen on", *eventsocket.Filename)
 	go eventSrv.Serve(ctx)
 
 	// Make the saver and construct the message channel, buffering up to 2 batches

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
-	"net"
 	"os"
 	"testing"
 
@@ -12,25 +10,20 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	portFinder, err := net.Listen("tcp", ":0")
-	rtx.Must(err, "Could not open server to discover open ports")
-	port := portFinder.Addr().(*net.TCPAddr).Port
-	portFinder.Close()
-
 	// Write files to a temp directory.
 	dir, err := ioutil.TempDir("", "TestMain")
 	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
 
-	// Make sure that starting up main() does not cause any panics. There's no a
-	// lot else we can test, but we can at least make sure that it at least doesn't
+	// Make sure that starting up main() does not cause any panics. There's not
+	// a lot else we can test, but we can at least make sure that it doesn't
 	// immediately crash.
 	for _, v := range []struct{ name, val string }{
 		{"REPS", "1"},
 		{"TRACE", "true"},
-		{"PROM", fmt.Sprintf(":%d", port)},
 		{"OUTPUT", dir},
-		{"EVENTSOCKET", dir + "/eventsock.sock"},
+		{"TCPINFO_EVENTSOCKET", dir + "/eventsock.sock"},
+		{"PROMETHEUSX_LISTEN_ADDRESS", ":0"},
 	} {
 		cleanup := osx.MustSetenv(v.name, v.val)
 		defer cleanup()


### PR DESCRIPTION
Part of the cleanup from https://github.com/m-lab/traceroute-caller/issues/38

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/110)
<!-- Reviewable:end -->
