### PR TITLE
Pass context through

### DIFF
--- a/eventsocket/client.go
+++ b/eventsocket/client.go
@@ -25,8 +25,8 @@ var (
 // notifications should implement. It has two methods, one called on Open events
 // and one called on Close events.
 type Handler interface {
-	Open(timestamp time.Time, uuid string, ID *inetdiag.SockID)
-	Close(timestamp time.Time, uuid string)
+	Open(ctx context.Context, timestamp time.Time, uuid string, ID *inetdiag.SockID)
+	Close(ctx context.Context, timestamp time.Time, uuid string)
 }
 
 // MustRun will read from the passed-in socket filename until the context is
@@ -50,9 +50,9 @@ func MustRun(ctx context.Context, socket string, handler Handler) {
 		rtx.Must(json.Unmarshal(s.Bytes(), &event), "Could not unmarshall")
 		switch event.Event {
 		case Open:
-			handler.Open(event.Timestamp, event.UUID, event.ID)
+			handler.Open(ctx, event.Timestamp, event.UUID, event.ID)
 		case Close:
-			handler.Close(event.Timestamp, event.UUID)
+			handler.Close(ctx, event.Timestamp, event.UUID)
 		default:
 			log.Println("Unknown event type:", event.Event)
 		}

--- a/eventsocket/client_test.go
+++ b/eventsocket/client_test.go
@@ -17,12 +17,12 @@ type testHandler struct {
 	wg            sync.WaitGroup
 }
 
-func (t *testHandler) Open(timestamp time.Time, uuid string, id *inetdiag.SockID) {
+func (t *testHandler) Open(ctx context.Context, timestamp time.Time, uuid string, id *inetdiag.SockID) {
 	t.opens++
 	t.wg.Done()
 }
 
-func (t *testHandler) Close(timestamp time.Time, uuid string) {
+func (t *testHandler) Close(ctx context.Context, timestamp time.Time, uuid string) {
 	t.closes++
 	t.wg.Done()
 }


### PR DESCRIPTION
The context should be available to the handlers in an effort to allow long-running handlers to be canceled without resorting to a side channel.

Part of the cleanup due to https://github.com/m-lab/traceroute-caller/issues/38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/111)
<!-- Reviewable:end -->
