### PR TITLE
Add two new tcpinfo fields

### DIFF
--- a/tcp/tcpinfo.go
+++ b/tcp/tcpinfo.go
@@ -53,7 +53,8 @@ func (x State) String() string {
 }
 
 // LinuxTCPInfo is the linux defined structure returned in RouteAttr DIAG_INFO messages.
-// It corresponds to the struct tcp_info in include/uapi/linux/tcp.h
+// It corresponds to the struct tcp_info in
+// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/tcp.h
 type LinuxTCPInfo struct {
 	State       uint8 `csv:"TCP.State"`
 	CAState     uint8 `csv:"TCP.CAState"`

--- a/tcp/tcpinfo.go
+++ b/tcp/tcpinfo.go
@@ -128,4 +128,8 @@ type LinuxTCPInfo struct {
 
 	DSackDups uint32 `csv:"TCP.DSackDups"` /* RFC4898 tcpEStatsStackDSACKDups */
 	ReordSeen uint32 `csv:"TCP.ReordSeen"` /* reordering events seen */
+
+	RcvOooPack uint32 `csv:"TCP.RcvOooPack"` /* Out-of-order packets received */
+
+	SndWnd uint32 `csv:"TCP.SndWnd"` /* peer's advertised receive window after scaling (bytes) */
 }


### PR DESCRIPTION
This adds two new fields that have been added in linux kernel to the corresponding message struct.

Parser will pick this up the next time we build or deploy etl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/123)
<!-- Reviewable:end -->
