### PR TITLE
Delete socket before trying to create a new one.

### DIFF
--- a/eventsocket/server.go
+++ b/eventsocket/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -120,6 +121,10 @@ func (s *server) Listen() error {
 	// definitely wait for Serve() to finish.
 	s.servingWG.Add(1)
 	var err error
+	// Delete any existing socket file before trying to listen on it. Unclean
+	// shutdowns can cause orphaned, stale socket files to hang around, causing
+	// this service to fail to start because it can't create the socket.
+	os.Readlink(s.filename)
 	s.unixListener, err = net.Listen("unix", s.filename)
 	return err
 }


### PR DESCRIPTION
This PR is intended to resolve https://github.com/m-lab/k8s-support/issues/492.  It takes attempts to resolve the issue the [same way that was used for the uuid-annotator](https://github.com/m-lab/uuid-annotator/pull/35). It deletes any potentially existing UNIX socket file before trying to set up a listener on a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/124)
<!-- Reviewable:end -->
