### PR TITLE
Actually remove the UNIX socket file.

### DIFF
--- a/eventsocket/server.go
+++ b/eventsocket/server.go
@@ -124,7 +124,7 @@ func (s *server) Listen() error {
 	// Delete any existing socket file before trying to listen on it. Unclean
 	// shutdowns can cause orphaned, stale socket files to hang around, causing
 	// this service to fail to start because it can't create the socket.
-	os.Readlink(s.filename)
+	os.Remove(s.filename)
 	s.unixListener, err = net.Listen("unix", s.filename)
 	return err
 }


### PR DESCRIPTION
PR #124 was supposed to fix an issue with a stale socket file preventing tcp-info from starting, but PR #124 was incorrect. This PR should actually remove the socket file and resolve issue #126 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/127)
<!-- Reviewable:end -->
