### PR TITLE
update code and tests to work correctly on Darwin

### DIFF
--- a/inetdiag/inetdiag_test.go
+++ b/inetdiag/inetdiag_test.go
@@ -1,6 +1,7 @@
 package inetdiag_test
 
 import (
+	"log"
 	"syscall"
 	"testing"
 	"unsafe"
@@ -8,6 +9,10 @@ import (
 	"github.com/m-lab/tcp-info/inetdiag"
 )
 
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 func TestSizes(t *testing.T) {
 	if unsafe.Offsetof(inetdiag.LinuxSockID{}.IDiagDPort) != 2 {
 		t.Error("Incorrect DPort offset")

--- a/inetdiag/structs.go
+++ b/inetdiag/structs.go
@@ -31,7 +31,6 @@ import (
 	"log"
 	"net"
 	"runtime"
-	"syscall"
 	"unsafe"
 
 	"github.com/m-lab/go/anonymize"
@@ -316,13 +315,14 @@ func (raw RawInetDiagMsg) Anonymize(anon anonymize.IPAnonymizer) error {
 	// to be encoded in the last 4 bytes of a 16 byte array. As a result, we must
 	// pass only 4 bytes to net.IP for AF_INET.
 	switch msg.IDiagFamily {
-	case syscall.AF_INET6:
+	case AF_INET6:
 		anon.IP(net.IP(msg.ID.IDiagSrc[:]))
 		anon.IP(net.IP(msg.ID.IDiagDst[:]))
-	case syscall.AF_INET:
+	case AF_INET:
 		anon.IP(net.IP(msg.ID.IDiagSrc[:4]))
 		anon.IP(net.IP(msg.ID.IDiagDst[:4]))
 	default:
+		log.Println(ErrUnknownAF, msg.IDiagFamily)
 		return ErrUnknownAF
 	}
 	return nil

--- a/inetdiag/structs_test.go
+++ b/inetdiag/structs_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"syscall"
 	"testing"
 	"unsafe"
 
@@ -14,6 +13,11 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/tcp-info/tcp"
 )
+
+func init() {
+	// Always prepend the filename and line number.
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+}
 
 // This needs to be a whitebox test because it tests unexported types.
 func TestStructAndCSVExport(t *testing.T) {
@@ -90,7 +94,7 @@ func TestParseInetDiagMsg(t *testing.T) {
 	if hdr.ID.Interface() == 0 || hdr.ID.Cookie() == 0 || hdr.ID.DPort() == 0 || toString(hdr.ID) == "" {
 		t.Errorf("None of the accessed values should be zero")
 	}
-	if hdr.IDiagFamily != syscall.AF_INET {
+	if hdr.IDiagFamily != AF_INET {
 		t.Errorf("Failed %+v\n", hdr)
 	}
 	if tcp.State(hdr.IDiagState) != tcp.SYN_RECV {
@@ -194,7 +198,7 @@ func TestID4Anonymize(t *testing.T) {
 
 	// Setup AF.
 	afOffset := unsafe.Offsetof(InetDiagMsg{}.IDiagFamily)
-	data[afOffset] = syscall.AF_INET
+	data[afOffset] = AF_INET
 
 	raw, _ := SplitInetDiagMsg(data[:])
 	hdr, err := raw.Parse()
@@ -255,7 +259,7 @@ func TestID6Anonymize(t *testing.T) {
 	}
 	// Setup AF.
 	afOffset := unsafe.Offsetof(InetDiagMsg{}.IDiagFamily)
-	data[afOffset] = syscall.AF_INET6
+	data[afOffset] = AF_INET6
 
 	raw, _ := SplitInetDiagMsg(data[:])
 	hdr, err := raw.Parse()


### PR DESCRIPTION
syscall.AF_INET causes tests to fail on Darwin.  This updates newer code to use inetdiag.AF_INET and AF_INET6 instead to preserve Darwin unit test compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/128)
<!-- Reviewable:end -->
