### PR TITLE
Fix README typos and clarify

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ implementation `cmd/example-eventsocket-client` can be started using
 `docker-compose`.
 
 ```bash
-docker-compse up
+docker-compose up
 ```
 
 New TCP events are processed by the `example-eventsocket-client` sidecar and

--- a/cmd/csvtool/README.md
+++ b/cmd/csvtool/README.md
@@ -1,14 +1,20 @@
 # csvtool
 
-The csvtool is intended to convert from ArchiveRecord files to CSV files.
-It currently only handles raw or zstd compressed JSONL files as source.
-It takes a single command line argument, which is the name of the file, or "-" to read uncompressed JSONL from stdin.
+The csvtool is intended to convert the ArchiveRecord file format produced by
+tcp-info to more easily usable CSV files. csvtool currently only handles
+individual, raw or zstd compressed JSONL files as a source.  Named files should
+be the only parameter. If reading uncompressed JSONL from STDIN, provide no
+argument.
 
-## Examples:
+## Examples
+
+Decompressing the JSONL file so that csvtool reads from stdin:
 
 ```bash
-zstd -cd 2019/04/01/ndt-jdczh_1553815964_00000000000003E8.00184.jsonl.zst | ./csvtool - > connection.csv
+zstd -cd 2019/04/01/ndt-jdczh_1553815964_00000000000003E8.00184.jsonl.zst | ./csvtool > connection.csv
 ```
+
+Directly read compressed format:
 
 ```bash
 ./csvtool 2019/04/01/ndt-jdczh_1553815964_00000000000003E8.00184.jsonl.zst > connection.csv


### PR DESCRIPTION
These changes fix two typos and clarifying language reported by a user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/132)
<!-- Reviewable:end -->
