### PR TITLE
Add option to exclude archival messages from traffic using source ports

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -27,11 +27,14 @@ func fakeMsg(t *testing.T, cookie uint64, dport uint16) netlink.ArchivalRecord {
 	if err != nil {
 		t.Fatal(err)
 	}
-	mp, err := netlink.MakeArchivalRecord(&nm, true)
+	mp, err := netlink.MakeArchivalRecord(&nm, &netlink.ExcludeConfig{Local: true})
 	if err != nil {
 		t.Fatal(err)
 	}
 	idm, err := mp.RawIDM.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i := 0; i < 8; i++ {
 		idm.ID.IDiagCookie[i] = byte(cookie & 0x0FF)
 		cookie >>= 8

--- a/collector/collector_linux_test.go
+++ b/collector/collector_linux_test.go
@@ -110,7 +110,7 @@ func TestRun(t *testing.T) {
 			if v4 == nil {
 				continue
 			}
-			m, err := netlink.MakeArchivalRecord(v4, false)
+			m, err := netlink.MakeArchivalRecord(v4, nil)
 			testFatal(t, err)
 			idm, err := m.RawIDM.Parse()
 			testFatal(t, err)
@@ -128,7 +128,7 @@ func TestRun(t *testing.T) {
 			if v6 == nil {
 				continue
 			}
-			m, err := netlink.MakeArchivalRecord(v6, false)
+			m, err := netlink.MakeArchivalRecord(v6, nil)
 			testFatal(t, err)
 			idm, err := m.RawIDM.Parse()
 			testFatal(t, err)

--- a/main.go
+++ b/main.go
@@ -111,8 +111,12 @@ func main() {
 	rtx.Must(eventSrv.Listen(), "Could not listen on", *eventsocket.Filename)
 	go eventSrv.Serve(ctx)
 
-	srcPorts := map[uint16]bool{}
+	ex := &netlink.ExcludeConfig{
+		Local: true,
+	}
+
 	if len(excludeSrcPorts) != 0 {
+		srcPorts := map[uint16]bool{}
 		for _, port := range excludeSrcPorts {
 			i, err := strconv.ParseInt(port, 10, 16)
 			if err != nil {
@@ -121,11 +125,7 @@ func main() {
 			}
 			srcPorts[uint16(i)] = true
 		}
-	}
-
-	ex := &netlink.ExcludeConfig{
-		Local:    true,
-		SrcPorts: srcPorts,
+		ex.SrcPorts = srcPorts
 	}
 
 	// Make the saver and construct the message channel, buffering up to 2 batches

--- a/saver/saver_test.go
+++ b/saver/saver_test.go
@@ -94,7 +94,7 @@ func (msg *TestMsg) setDPort(dport uint16) *TestMsg {
 }
 
 func (msg *TestMsg) mustAR() *netlink.ArchivalRecord {
-	ar, err := netlink.MakeArchivalRecord(&msg.NetlinkMessage, true)
+	ar, err := netlink.MakeArchivalRecord(&msg.NetlinkMessage, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -219,7 +219,7 @@ func TestHistograms(t *testing.T) {
 	}()
 	eventCounts := &countingEventSocket{}
 	anon := anonymize.New(anonymize.None)
-	svr := saver.NewSaver("foo", "bar", 1, eventCounts, anon)
+	svr := saver.NewSaver("foo", "bar", 1, eventCounts, anon, nil)
 	svrChan := make(chan netlink.MessageBlock, 0) // no buffering
 	go svr.MessageSaverLoop(svrChan)
 
@@ -340,7 +340,7 @@ func TestFinWait2NotImplemented(t *testing.T) {
 	}
 
 	anon := anonymize.New(anonymize.None)
-	svr := saver.NewSaver("hostname", "fakePod", 1, eventsocket.NullServer(), anon)
+	svr := saver.NewSaver("hostname", "fakePod", 1, eventsocket.NullServer(), anon, nil)
 	blockChan := make(chan netlink.MessageBlock, 0)
 	go svr.MessageSaverLoop(blockChan)
 	for i := range msgs {


### PR DESCRIPTION
This change adds a new optional flag to tcp-info, `-exclude-srcport`. With this flag, a list of local source ports may be provided, which tcp-info will use to exclude all snapshots with these source ports from being saved to archival data.

To support this feature, this change introduces a new type, `netlink.ExcludeConfig`. The `ExcludeConfig` replaces the `skipLocal` parameter in the `saver.Saver` and `netlink.MakeArchivalRecord` in favor of a structure that can specify multiple options, or be extended to support more in the future.

This change preserves previous default behavior.

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/136)
<!-- Reviewable:end -->
