### PR TITLE
Exclude DstIPs

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -32,3 +32,55 @@ func TestMain(t *testing.T) {
 	// REPS=1 should cause main to run once and then exit.
 	main()
 }
+
+func TestMainWithExcludeOptions(t *testing.T) {
+	// Write files to a temp directory.
+	dir, err := ioutil.TempDir("", "TestMain")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+
+	// Make sure that starting up main() does not cause any panics. There's not
+	// a lot else we can test, but we can at least make sure that it doesn't
+	// immediately crash.
+	for _, v := range []struct{ name, val string }{
+		{"REPS", "1"},
+		{"TRACE", "true"},
+		{"OUTPUT", dir},
+		{"TCPINFO_EVENTSOCKET", dir + "/eventsock.sock"},
+		{"PROMETHEUSX_LISTEN_ADDRESS", ":0"},
+		{"EXCLUDE_SRCPORT", "443"},
+		{"EXCLUDE_DSTIP", "172.25.0.1"},
+	} {
+		cleanup := osx.MustSetenv(v.name, v.val)
+		defer cleanup()
+	}
+
+	// REPS=1 should cause main to run once and then exit.
+	main()
+}
+
+func TestMainWithBadExcludeOptions(t *testing.T) {
+	// Write files to a temp directory.
+	dir, err := ioutil.TempDir("", "TestMain")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+
+	// Make sure that starting up main() does not cause any panics. There's not
+	// a lot else we can test, but we can at least make sure that it doesn't
+	// immediately crash.
+	for _, v := range []struct{ name, val string }{
+		{"REPS", "1"},
+		{"TRACE", "true"},
+		{"OUTPUT", dir},
+		{"TCPINFO_EVENTSOCKET", dir + "/eventsock.sock"},
+		{"PROMETHEUSX_LISTEN_ADDRESS", ":0"},
+		{"EXCLUDE_SRCPORT", "NOT_AN_INT"},
+		{"EXCLUDE_DSTIP", ";not-an-ip;"},
+	} {
+		cleanup := osx.MustSetenv(v.name, v.val)
+		defer cleanup()
+	}
+
+	// REPS=1 should cause main to run once and then exit.
+	main()
+}

--- a/netlink/archival-record.go
+++ b/netlink/archival-record.go
@@ -58,6 +58,7 @@ type ExcludeConfig struct {
 	DstIPs   map[[16]byte]bool
 }
 
+// AddSrcPort adds the given port to the set of source ports to exclude.
 func (ex *ExcludeConfig) AddSrcPort(port string) error {
 	i, err := strconv.ParseInt(port, 10, 16)
 	if err != nil {
@@ -70,6 +71,7 @@ func (ex *ExcludeConfig) AddSrcPort(port string) error {
 	return nil
 }
 
+// AddDstIP adds the given dst IP address to the set of destination IPs to exclude.
 func (ex *ExcludeConfig) AddDstIP(dst string) error {
 	ip := net.ParseIP(dst)
 	if ip == nil {

--- a/netlink/archival-record.go
+++ b/netlink/archival-record.go
@@ -80,16 +80,16 @@ func (ex *ExcludeConfig) AddDstIP(dst string) error {
 	if ex.DstIPs == nil {
 		ex.DstIPs = map[[16]byte]bool{}
 	}
-	buf := [16]byte{}
+	key := [16]byte{}
 	if ip.To4() != nil {
 		// NOTE: The Linux-native byte position for IPv4 addresses is the first four bytes.
 		// The net.IP package format uses the last four bytes. Copy the net.IP bytes to a
 		// new array to generate a key for dstIPs.
-		copy(buf[:], ip[12:])
+		copy(key[:], ip[12:])
 	} else {
-		copy(buf[:], ip[:])
+		copy(key[:], ip[:])
 	}
-	ex.DstIPs[buf] = true
+	ex.DstIPs[key] = true
 	return nil
 }
 

--- a/netlink/archival-record.go
+++ b/netlink/archival-record.go
@@ -53,6 +53,7 @@ type ExcludeConfig struct {
 	Local bool
 	// SrcPorts excludes connections from specific source ports.
 	SrcPorts map[uint16]bool
+	DstIPs   map[[16]byte]bool
 }
 
 // ParseRouteAttr parses a byte array into slice of NetlinkRouteAttr struct.
@@ -92,6 +93,12 @@ func MakeArchivalRecord(msg *NetlinkMessage, exclude *ExcludeConfig) (*ArchivalR
 			return nil, nil
 		}
 		if exclude.Local && (isLocal(idm.ID.SrcIP()) || isLocal(idm.ID.DstIP())) {
+			return nil, nil
+		}
+		if exclude.DstIPs != nil && exclude.DstIPs[idm.ID.IDiagDst] {
+			// Note: byte-key lookup is preferable for performance than
+			// net.IP-to-String formatting. And, a byte array can be a map key,
+			// while a net.IP byte slice cannot.
 			return nil, nil
 		}
 	}

--- a/netlink/archival-record_test.go
+++ b/netlink/archival-record_test.go
@@ -1,0 +1,81 @@
+// Package netlink contains the bare minimum needed to partially parse netlink messages.
+package netlink
+
+import (
+	"testing"
+	"unsafe"
+
+	//"github.com/m-lab/go/pretty"
+
+	"github.com/m-lab/tcp-info/inetdiag"
+)
+
+func inet2bytes(inet *inetdiag.InetDiagMsg) []byte {
+	const sz = int(unsafe.Sizeof(inetdiag.InetDiagMsg{}))
+	return (*[sz]byte)(unsafe.Pointer(inet))[:]
+}
+
+func TestMakeArchivalRecord(t *testing.T) {
+	//fmt.Println(s)
+	// ptr := unsafe.Pointer(&inet)
+	// (*[len]ArbitraryType)(unsafe.Pointer(ptr))[:]
+	// return (*InetDiagMsg)(unsafe.Pointer(&raw[0])), nil
+	id := inetdiag.LinuxSockID{
+		IDiagSPort: [2]byte{0, 77},          // src port
+		IDiagSrc:   [16]byte{127, 0, 0, 1},  // localhost
+		IDiagDst:   [16]byte{172, 25, 0, 1}, // dst ip
+	}
+	tests := []struct {
+		name    string
+		msg     *NetlinkMessage
+		exclude *ExcludeConfig
+		want    *ArchivalRecord
+		wantErr bool
+	}{
+		{
+			name: "exclude-local",
+			msg: &NetlinkMessage{
+				Header: NlMsghdr{Type: 20},
+				Data:   inet2bytes(&inetdiag.InetDiagMsg{ID: id}),
+			},
+			exclude: &ExcludeConfig{
+				Local: true,
+			},
+		},
+		{
+			name: "exclude-srcport",
+			msg: &NetlinkMessage{
+				Header: NlMsghdr{Type: 20},
+				Data:   inet2bytes(&inetdiag.InetDiagMsg{ID: id}),
+			},
+			exclude: &ExcludeConfig{
+				SrcPorts: map[uint16]bool{77: true},
+			},
+		},
+		{
+			name: "exclude-dstip",
+			msg: &NetlinkMessage{
+				Header: NlMsghdr{Type: 20},
+				Data:   inet2bytes(&inetdiag.InetDiagMsg{ID: id}),
+			},
+			exclude: &ExcludeConfig{
+				DstIPs: map[[16]byte]bool{[16]byte{172, 25, 0, 1}: true},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// All cases should return nil.
+			got, err := MakeArchivalRecord(tt.msg, tt.exclude)
+			if err != nil {
+				t.Errorf("MakeArchivalRecord() error = %v, wantErr nil", err)
+				return
+			}
+			if got != nil {
+				t.Errorf("MakeArchivalRecord() = %v, want nil", got)
+			}
+		})
+	}
+	/*
+	 */
+}

--- a/netlink/archival-record_test.go
+++ b/netlink/archival-record_test.go
@@ -82,7 +82,7 @@ func TestExcludeConfig_AddSrcPort(t *testing.T) {
 	}{
 		{
 			name: "success",
-			port: "9999", // "not-a-port"},
+			port: "9999",
 			wantPorts: map[uint16]bool{
 				9999: true,
 			},

--- a/netlink/archival-record_test.go
+++ b/netlink/archival-record_test.go
@@ -71,8 +71,6 @@ func TestMakeArchivalRecord(t *testing.T) {
 			}
 		})
 	}
-	/*
-	 */
 }
 
 func TestExcludeConfig_AddSrcPort(t *testing.T) {


### PR DESCRIPTION
This change adds a repeatable option to `-exlude-dstip=`. This is a continuation of functionality added in https://github.com/m-lab/tcp-info/pull/136 and will allow excluding known operational addresses from archival data.

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/137)
<!-- Reviewable:end -->
