### PR TITLE
Add flow_events_total metric to count flow events

### DIFF
--- a/eventsocket/server.go
+++ b/eventsocket/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/m-lab/tcp-info/inetdiag"
+	"github.com/m-lab/tcp-info/metrics"
 )
 
 //go:generate stringer -type=TCPEvent
@@ -172,6 +173,7 @@ func (s *server) FlowCreated(timestamp time.Time, uuid string, id inetdiag.SockI
 		ID:        &id,
 		UUID:      uuid,
 	}
+	metrics.FlowEventsCounter.WithLabelValues("open").Inc()
 }
 
 // FlowDeleted should be called whenever tcpinfo notices a flow has been retired.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -2,9 +2,9 @@
 // methods to add accounting to various parts of the pipeline.
 //
 // When defining new operations or metrics, these are helpful values to track:
-//  - things coming into or go out of the system: requests, files, tests, api calls.
-//  - the success or error status of any of the above.
-//  - the distribution of processing latency.
+//   - things coming into or go out of the system: requests, files, tests, api calls.
+//   - the success or error status of any of the above.
+//   - the distribution of processing latency.
 package metrics
 
 import (
@@ -167,6 +167,13 @@ var (
 			Name: "netlink_skipped_total",
 			Help: "Number of skipped netlink messages.",
 		}, []string{"type"},
+	)
+
+	FlowEventsCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "tcpinfo_flow_events_total",
+			Help: "Number of flow events by event type.",
+		}, []string{"event"},
 	)
 )
 


### PR DESCRIPTION
This PR adds the `tcpinfo_flow_events_total` counter metric to count the number of "flow created" events (and potentially "flow deleted" in the future, using the same metric with a different label value). This will be useful to compare flow creation events in tcp-info vs the number of events processed by each of eventsocket's clients.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/tcp-info/140)
<!-- Reviewable:end -->
